### PR TITLE
Fix "Publish gh pages" workflow

### DIFF
--- a/.github/workflows/publish-rustdoc.yaml
+++ b/.github/workflows/publish-rustdoc.yaml
@@ -4,7 +4,7 @@ name: Publish Rustdoc to GitHub Pages
 on:
   # Triggers the workflow on push or pull request events but only for the "devel" branch
   push:
-    # branches: [ "devel" ]
+    branches: [ "devel" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish-rustdoc.yaml
+++ b/.github/workflows/publish-rustdoc.yaml
@@ -4,7 +4,7 @@ name: Publish Rustdoc to GitHub Pages
 on:
   # Triggers the workflow on push or pull request events but only for the "devel" branch
   push:
-    branches: [ "devel" ]
+    # branches: [ "devel" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -21,6 +21,10 @@ cargo doc --no-deps # saves doc in $DOC_FOLDER_MAIN_BRANCH
 git fetch
 git checkout "$TARGET_BRANCH"
 
+echo "printing out PWD"
+pwd
+echo "done printing PWD"
+
 rm -rf DOC_FOLDER_TARGET_BRANCH
 mv -f "${DOC_FOLDER_MAIN_BRANCH}" "${DOC_FOLDER_TARGET_BRANCH}" 
 echo "<meta http-equiv=refresh content=0;url=${DOC_FOLDER_TARGET_BRANCH}/${DOC_INDEX_PAGE}>" > "index.html"

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -6,7 +6,7 @@ set -eu
 
 REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 REMOTE_NAME="origin"
-MAIN_BRANCH="main"
+MAIN_BRANCH="devel"
 TARGET_BRANCH="gh-pages"
 DOC_FOLDER_MAIN_BRANCH="target/doc"
 DOC_FOLDER_TARGET_BRANCH="doc"
@@ -21,15 +21,11 @@ cargo doc --no-deps # saves doc in $DOC_FOLDER_MAIN_BRANCH
 git fetch
 git checkout "$TARGET_BRANCH"
 
-echo "printing out PWD"
-pwd
-echo "done printing PWD"
-
-rm -rf DOC_FOLDER_TARGET_BRANCH
-mv -f "${DOC_FOLDER_MAIN_BRANCH}" "${DOC_FOLDER_TARGET_BRANCH}" 
+rm -rf "${DOC_FOLDER_TARGET_BRANCH}" # because of the `-f` flag, no errors will be outputted if the folder doesn't exist
+cp -r "${DOC_FOLDER_MAIN_BRANCH}/." "${DOC_FOLDER_TARGET_BRANCH}" 
 echo "<meta http-equiv=refresh content=0;url=${DOC_FOLDER_TARGET_BRANCH}/${DOC_INDEX_PAGE}>" > "index.html"
 
-git add "$DOC_FOLDER_TARGET_BRANCH"
+git add "${DOC_FOLDER_TARGET_BRANCH}"
 git add "index.html"
 
 git commit -m "Updated GitHub Pages"


### PR DESCRIPTION
It wasn't working because in the shell script `scripts/update-gh-pages.sh`:

- There was a typo when performing `rm`
- I was using `mv` instead of `cp`