### PR TITLE
Get protos by trait info

### DIFF
--- a/pallets/fragments/src/lib.rs
+++ b/pallets/fragments/src/lib.rs
@@ -442,8 +442,12 @@ pub mod pallet {
 			// create vault account
 			// we need an existential amount deposit to be able to create the vault account
 			let vault = Self::get_vault_id(hash);
-			let min_balance = <T as pallet_assets::Config>::Currency::minimum_balance();
-			<T as pallet_assets::Config>::Currency::reserve(&vault, min_balance)?;
+			let min_balance =
+				<pallet_balances::Pallet<T> as Currency<T::AccountId>>::minimum_balance();
+			let _ = <pallet_balances::Pallet<T> as Currency<T::AccountId>>::deposit_creating(
+				&vault,
+				min_balance,
+			);
 
 			let fragment_data = FragmentDefinition {
 				proto_hash,
@@ -955,10 +959,10 @@ pub mod pallet {
 			let frag_account = Self::get_fragment_account_id(class, edition, copy);
 			let min_balance =
 				<pallet_balances::Pallet<T> as Currency<T::AccountId>>::minimum_balance();
-			<pallet_balances::Pallet<T> as ReservableCurrency<T::AccountId>>::reserve(
+			let _ = <pallet_balances::Pallet<T> as Currency<T::AccountId>>::deposit_creating(
 				&frag_account,
 				min_balance,
-			)?;
+			);
 
 			// TODO Make owner pay for deposit actually!
 			// TODO setup proxy

--- a/pallets/protos/src/dummy_data.rs
+++ b/pallets/protos/src/dummy_data.rs
@@ -13,7 +13,7 @@ use sp_core::{
 
 use sp_clamor::{Hash256, CID_PREFIX};
 
-use protos::categories::{Categories, TextCategories};
+use protos::categories::{Categories, ShardsTraitInfo, TextCategories};
 
 pub fn compute_data_hash(data: &Vec<u8>) -> Hash256 {
 	blake2_256(&data)
@@ -89,6 +89,9 @@ impl Stake {
 pub struct DummyData {
 	pub proto_fragment: ProtoFragment,
 	pub proto_fragment_second: ProtoFragment,
+	pub proto_fragment_third: ProtoFragment,
+	pub proto_fragment_fourth: ProtoFragment,
+	pub proto_fragment_fifth: ProtoFragment,
 	pub patch: Patch,
 	pub metadata: Metadata,
 	pub stake: Stake,
@@ -115,6 +118,54 @@ impl DummyData {
 			linked_asset: None,
 			include_cost: Some(2),
 			data: "0x222".as_bytes().to_vec(),
+		};
+
+		let num: [u8; 16] = [1u8; 16];
+		let shard = ShardsTraitInfo {
+			name: "Shards1".to_string(),
+			description: "test 1".to_string(),
+			id: num,
+		};
+
+		let proto_third = ProtoFragment {
+			references: Vec::new(),
+			category: Categories::Trait(shard),
+			tags: Vec::new(),
+			linked_asset: None,
+			include_cost: Some(2),
+			data: "0x224".as_bytes().to_vec(),
+		};
+
+		let num2: [u8; 16] = [13u8; 16];
+		let shard2 = ShardsTraitInfo {
+			name: "NameOfShard".to_string(),
+			description: "description".to_string(),
+			id: num2,
+		};
+
+		let proto_fourth = ProtoFragment {
+			references: Vec::new(),
+			category: Categories::Trait(shard2),
+			tags: Vec::new(),
+			linked_asset: None,
+			include_cost: Some(2),
+			data: "0x1840923".as_bytes().to_vec(),
+		};
+
+		let num3: [u8; 16] = [4u8; 16];
+		let shard3 = ShardsTraitInfo {
+			name: "NameOfShard".to_string(),
+			description: "description2".to_string(),
+			id: num3,
+		};
+
+		let proto_fifth = ProtoFragment {
+			references: Vec::new(),
+			category: Categories::Trait(shard3),
+			tags: Vec::new(),
+			linked_asset: None,
+			include_cost: Some(2),
+			data: "0x1845923".as_bytes().to_vec(),
 		};
 
 		let patch = Patch {
@@ -181,6 +232,9 @@ impl DummyData {
 		Self {
 			proto_fragment: proto,
 			proto_fragment_second: proto_second,
+			proto_fragment_third: proto_third,
+			proto_fragment_fourth: proto_fourth,
+			proto_fragment_fifth: proto_fifth,
 			patch,
 			metadata,
 			stake,

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -1,18 +1,14 @@
 use crate as pallet_protos;
-use crate::dummy_data::*;
-use crate::mock;
-use crate::mock::*;
-use crate::*;
+use crate::{dummy_data::*, mock, mock::*, *};
 use codec::Compact;
-use frame_support::dispatch::DispatchResult;
-use frame_support::{assert_noop, assert_ok, traits::Get};
+use frame_support::{assert_noop, assert_ok, dispatch::DispatchResult, traits::Get};
 use std::collections::BTreeMap;
 
 use stake_tests::stake_;
 use upload_tests::upload;
 
-use copied_from_pallet_accounts::link_;
-use copied_from_pallet_accounts::lock_;
+use copied_from_pallet_accounts::{link_, lock_};
+use protos::categories::{ShardsTraitInfo, TextCategories};
 
 mod copied_from_pallet_accounts {
 	use super::*;
@@ -63,8 +59,8 @@ mod upload_tests {
 
 			let proto_struct = <Protos<Test>>::get(proto.get_proto_hash()).unwrap();
 
-			// I am using `match` to ensure that this test case fails if a new field is ever added to the `Proto` struct
-			// match proto_struct {
+			// I am using `match` to ensure that this test case fails if a new field is ever added
+			// to the `Proto` struct match proto_struct {
 			// 	Proto {
 			// 		block: 1,
 			// 		patches: Vec::new(),
@@ -143,13 +139,11 @@ mod upload_tests {
 			assert_ok!(lock_(&stake.lock));
 			assert_ok!(link_(&stake.lock.link));
 
-			assert_ok!(
-				stake_(
-					stake.lock.link.clamor_account_id,
-					&stake.proto_fragment,
-					&stake.get_stake_amount(),
-				)
-			);
+			assert_ok!(stake_(
+				stake.lock.link.clamor_account_id,
+				&stake.proto_fragment,
+				&stake.get_stake_amount(),
+			));
 
 			let proto_with_refs = ProtoFragment {
 				references: vec![stake.proto_fragment.get_proto_hash()],
@@ -174,13 +168,11 @@ mod upload_tests {
 			assert_ok!(lock_(&stake.lock));
 			assert_ok!(link_(&stake.lock.link));
 
-			assert_ok!(
-				stake_(
-					stake.lock.link.clamor_account_id,
-					&stake.proto_fragment,
-					&(stake.get_stake_amount() - 1),
-				)
-			);
+			assert_ok!(stake_(
+				stake.lock.link.clamor_account_id,
+				&stake.proto_fragment,
+				&(stake.get_stake_amount() - 1),
+			));
 
 			let proto_with_refs = ProtoFragment {
 				references: vec![stake.proto_fragment.get_proto_hash()],
@@ -219,6 +211,289 @@ mod upload_tests {
 	}
 }
 
+mod get_protos_tests {
+	use super::*;
+	use upload_tests::upload;
+
+	#[test]
+	fn get_protos_should_not_work_if_owner_not_exists() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto = dd.proto_fragment_third;
+			let proto_text = dd.proto_fragment_second;
+
+			assert_ok!(upload(dd.account_id, &proto));
+			assert_ok!(upload(dd.account_id_second, &proto_text));
+
+			// SEARCH
+			let num: [u8; 16] = [1; 16];
+			let shard = ShardsTraitInfo {
+				name: "Shards1".to_string(),
+				description: "test 1".to_string(),
+				id: num,
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 10u64,
+				limit: 20u64,
+				metadata_keys: Vec::new(),
+				owner: Some(sp_core::ed25519::Public::from_raw([13u8; 32])), // different from account_id
+				return_owners: false,
+				categories: vec![Categories::Trait(shard)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result: Result<Vec<u8>,Vec<u8>>  = ProtosPallet::get_protos(params);
+			assert_eq!(result.err(), Some("Owner not found".as_bytes().to_vec()));
+		});
+	}
+
+	#[test]
+	fn get_protos_by_category_other_than_trait_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto = dd.proto_fragment;
+			let proto_trait = dd.proto_fragment_fourth;
+
+			assert_ok!(upload(dd.account_id, &proto));
+			assert_ok!(upload(dd.account_id, &proto_trait));
+
+			// SEARCH
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: Some(dd.account_id),
+				return_owners: true,
+				categories: vec![Categories::Text(TextCategories::Plain)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			// proto_id (taken from the test output)
+			let json_expected_start = concat!("{\"1e8a88bae82e70417a366e597bc307960c860ab3f53353e348fb0594cffb773b\":{", 
+				"\"include_cost\":867,",
+				"\"owner\":{",
+					"\"type\":\"internal\",",
+					"\"value\":\"").to_owned();
+
+			let account_id_hex = hex::encode(dd.account_id).to_owned();
+			let json_expected_end = "\"}}}".to_owned();
+
+			let partial = format!("{}{}", json_expected_start, account_id_hex);
+			let json_expected = format!("{}{}", partial, json_expected_end);
+
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_exactly_same_trait_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto = dd.proto_fragment_third;
+
+			assert_ok!(upload(dd.account_id, &proto));
+
+			// SEARCH
+			let num: [u8; 16] = [1u8; 16];
+			let shard = ShardsTraitInfo {
+				name: "Shards1".to_string(),
+				description: "test 1".to_string(),
+				id: num,
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: Some(dd.account_id),
+				return_owners: true,
+				categories: vec![Categories::Trait(shard)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			// proto_id (taken from the test output)
+			let json_expected_start = concat!("{\"c1e9b40c2b6fddd4685fa881c64a461715be25ebee8a1cbf609f38f253ee1b05\":{", 
+				"\"include_cost\":2,",
+				"\"owner\":{",
+					"\"type\":\"internal\",",
+					"\"value\":\"").to_owned();
+
+			let account_id_hex = hex::encode(dd.account_id).to_owned();
+			let json_expected_end = "\"}}}".to_owned();
+
+			let partial = format!("{}{}", json_expected_start, account_id_hex);
+			let json_expected = format!("{}{}", partial, json_expected_end);
+
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_trait_name_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto = dd.proto_fragment_third;
+
+			assert_ok!(upload(dd.account_id, &proto));
+
+			// SEARCH
+			// This is searching a Proto using the same Trait name.
+			// Note that Trait description is different from the trait uploaded.
+			let num: [u8; 16] = [0u8; 16]; // trait ID is set to all zeroes for the search by name
+			let shard = ShardsTraitInfo {
+				name: "Shards1".to_string(),
+				description: "test 2".to_string(), // this description is different from the proto stored (i.e. test 1)
+				id: num,
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: Some(dd.account_id),
+				return_owners: true,
+				categories: vec![Categories::Trait(shard)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			// proto_id (taken from the test output)
+			let json_expected_start = concat!("{\"c1e9b40c2b6fddd4685fa881c64a461715be25ebee8a1cbf609f38f253ee1b05\":{", 
+				"\"include_cost\":2,",
+				"\"owner\":{",
+					"\"type\":\"internal\",",
+					"\"value\":\"").to_owned();
+
+			let account_id_hex = hex::encode(dd.account_id).to_owned();
+			let json_expected_end = "\"}}}".to_owned();
+
+			let partial = format!("{}{}", json_expected_start, account_id_hex);
+			let json_expected = format!("{}{}", partial, json_expected_end);
+
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_trait_name_with_multiple_protos_stored_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			// Two protos with different trait names
+			let proto1 = dd.proto_fragment_third;
+			let proto2 = dd.proto_fragment_fourth;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id, &proto2));
+
+			// SEARCH
+			let num: [u8; 16] = [0u8; 16];
+			let shard = ShardsTraitInfo {
+				name: "NameOfShard".to_string(), // proto_fragment_fourth
+				description: "test 2".to_string(), // this description is different from the proto stored (i.e. test 1)
+				id: num,
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Trait(shard)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			// proto_id (taken from the test output)
+			let json_expected_start = concat!("{\"57b3c115913e6bcc8cf6e2d8834a6d9e8f942606789ed25f1d969641a8db3b2f\":{", 
+				"\"include_cost\":2,",
+				"\"owner\":{",
+					"\"type\":\"internal\",",
+					"\"value\":\"").to_owned();
+
+			let account_id_hex = hex::encode(dd.account_id).to_owned();
+			let json_expected_end = "\"}}}".to_owned();
+
+			let partial = format!("{}{}", json_expected_start, account_id_hex);
+			let json_expected = format!("{}{}", partial, json_expected_end);
+
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_trait_name_should_return_two_protos() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto = dd.proto_fragment_fourth;
+			let proto2 = dd.proto_fragment_fifth;
+			// Upload twice the same Proto
+			assert_ok!(upload(dd.account_id, &proto));
+			assert_ok!(upload(dd.account_id, &proto2));
+
+			// SEARCH
+			let num: [u8; 16] = [0u8; 16];
+			let shard = ShardsTraitInfo {
+				name: "NameOfShard".to_string(), // proto_fragment_fourth
+				description: "test 2".to_string(), // this description is different from the other protos stored
+				id: num,
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Trait(shard)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			// proto_id (taken from the test output)
+			let json_expected = concat!(
+				"{\"1c5993df79040a6015905dad4a0d787d65d6c84b2ff58c733bc7c8e93fe1c10c\":{",
+				"\"include_cost\":2,",
+				"\"owner\":{",
+				"\"type\":\"internal\",",
+				"\"value\":\"0101010101010101010101010101010101010101010101010101010101010101\"}},",
+				"\"57b3c115913e6bcc8cf6e2d8834a6d9e8f942606789ed25f1d969641a8db3b2f\":{",
+				"\"include_cost\":2,",
+				"\"owner\":{",
+				"\"type\":\"internal\",",
+				"\"value\":\"0101010101010101010101010101010101010101010101010101010101010101\"}}}");
+
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+}
 mod patch_tests {
 	use super::*;
 
@@ -306,13 +581,11 @@ mod patch_tests {
 			assert_ok!(lock_(&stake.lock));
 			assert_ok!(link_(&stake.lock.link));
 
-			assert_ok!(
-				stake_(
-					stake.lock.link.clamor_account_id,
-					&stake.proto_fragment,
-					&stake.get_stake_amount(),
-				)
-			);
+			assert_ok!(stake_(
+				stake.lock.link.clamor_account_id,
+				&stake.proto_fragment,
+				&stake.get_stake_amount(),
+			));
 
 			assert_ok!(upload(stake.lock.link.clamor_account_id, &dd.proto_fragment));
 
@@ -341,13 +614,11 @@ mod patch_tests {
 			assert_ok!(lock_(&stake.lock));
 			assert_ok!(link_(&stake.lock.link));
 
-			assert_ok!(
-				stake_(
-					stake.lock.link.clamor_account_id,
-					&stake.proto_fragment,
-					&(stake.get_stake_amount() - 1),
-				)
-			);
+			assert_ok!(stake_(
+				stake.lock.link.clamor_account_id,
+				&stake.proto_fragment,
+				&(stake.get_stake_amount() - 1),
+			));
 
 			assert_ok!(upload(stake.lock.link.clamor_account_id, &dd.proto_fragment));
 
@@ -477,8 +748,8 @@ mod transfer_tests {
 			assert!(
 				<ProtosByOwner<Test>>::get(ProtoOwner::User(dd.account_id))
 					.unwrap()
-					.contains(&proto.get_proto_hash())
-					== false
+					.contains(&proto.get_proto_hash()) ==
+					false
 			);
 			assert!(<ProtosByOwner<Test>>::get(ProtoOwner::User(dd.account_id_second))
 				.unwrap()
@@ -603,7 +874,6 @@ mod set_metadata_tests {
 		});
 	}
 }
-
 
 mod stake_tests {
 	use super::*;
@@ -787,7 +1057,8 @@ mod unstake_tests {
 				stake.lock.link.clamor_account_id,
 				&stake.proto_fragment,
 				&stake.get_stake_amount(),
-			).unwrap();
+			)
+			.unwrap();
 
 			let lockup_period =
 				<<Test as pallet_protos::Config>::StakeLockupPeriod as Get<u64>>::get(); // .saturated_into(); - @sinkingsugar: what is `.saturated_into())`
@@ -811,8 +1082,8 @@ mod unstake_tests {
 			assert!(
 				<AccountStakes<Test>>::get(stake.lock.link.clamor_account_id)
 					.unwrap()
-					.contains(&stake.proto_fragment.get_proto_hash())
-					== false
+					.contains(&stake.proto_fragment.get_proto_hash()) ==
+					false
 			);
 
 			let event = <frame_system::Pallet<Test>>::events()
@@ -863,13 +1134,11 @@ mod unstake_tests {
 
 			assert_ok!(lock_(&stake.lock));
 			assert_ok!(link_(&stake.lock.link));
-			assert_ok!(
-				stake_(
-					stake.lock.link.clamor_account_id,
-					&stake.proto_fragment,
-					&stake.get_stake_amount(),
-				)
-			);
+			assert_ok!(stake_(
+				stake.lock.link.clamor_account_id,
+				&stake.proto_fragment,
+				&stake.get_stake_amount(),
+			));
 
 			let lockup_period =
 				<<Test as pallet_protos::Config>::StakeLockupPeriod as Get<u64>>::get(); // .saturated_into(); - @sinkingsugar: what is `.saturated_into())`

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -19,7 +19,8 @@ git config user.email "$BOT_EMAIL"
 cargo doc --no-deps # saves doc in $DOC_FOLDER_MAIN_BRANCH
 
 git fetch
-git checkout "$TARGET_BRANCH"
+# We use the `--force` flag because sometimes `cargo doc` causes the Cargo.lock to be altered. So if we don't use `--force`, we can't checkout the branch `$TARGET_BRANCH`.
+git checkout --force "$TARGET_BRANCH" # What the `--force` flag does: "When switching branches, proceed even if the index or the working tree differs from HEAD. This is used to throw away local changes."
 
 rm -rf "${DOC_FOLDER_TARGET_BRANCH}" # because of the `-f` flag, no errors will be outputted if the folder doesn't exist
 cp -r "${DOC_FOLDER_MAIN_BRANCH}/." "${DOC_FOLDER_TARGET_BRANCH}" 


### PR DESCRIPTION
This PR increases the granularity of `get_protos` in case the category in input is `Categories::Trait(ShardsTraitInfo)`.
It makes it possible to search Protos by `ShardsTraitInfo.name` or `ShardsTraitInfo.id` using these patterns:
- if the `Category::Trait` in input contains `ShardsTraitInfo.id = [0u8; 16]`, then `get_protos` will search by `ShardsTraitInfo.name`
- if the `Category::Trait` in input contains `ShardsTraitInfo.name = ""`, then it will search by `ShardsTraitInfo.id`