### PR TITLE
Get protos by shards scripts filter (issue #128)

### DIFF
--- a/pallets/protos/src/dummy_data.rs
+++ b/pallets/protos/src/dummy_data.rs
@@ -13,7 +13,7 @@ use sp_core::{
 
 use sp_clamor::{Hash256, CID_PREFIX};
 
-use protos::categories::{Categories, ShardsTraitInfo, TextCategories};
+use protos::categories::{Categories, ShardsTraitInfo, TextCategories, ShardsFormat, ShardsScriptInfo};
 
 pub fn compute_data_hash(data: &Vec<u8>) -> Hash256 {
 	blake2_256(&data)
@@ -92,6 +92,8 @@ pub struct DummyData {
 	pub proto_fragment_third: ProtoFragment,
 	pub proto_fragment_fourth: ProtoFragment,
 	pub proto_fragment_fifth: ProtoFragment,
+	pub proto_shard_script: ProtoFragment,
+	pub proto_shard_script_2: ProtoFragment,
 	pub patch: Patch,
 	pub metadata: Metadata,
 	pub stake: Stake,
@@ -168,6 +170,39 @@ impl DummyData {
 			data: "0x666".as_bytes().to_vec(),
 		};
 
+		let shard_script_num_1: [u8; 16] = [4u8; 16];
+		let shard_script_num_2: [u8; 16] = [5u8; 16];
+		let shard_script = ShardsScriptInfo {
+			format: ShardsFormat::Edn,
+			requiring: vec![shard_script_num_1],
+			implementing: vec![shard_script_num_2],
+		};
+
+		let proto_shard_script = ProtoFragment {
+			references: Vec::new(),
+			category: Categories::Shards(shard_script),
+			tags: Vec::new(),
+			linked_asset: None,
+			include_cost: Some(2),
+			data: "0x661".as_bytes().to_vec(),
+		};
+
+		let shard_script_num_3: [u8; 16] = [9u8; 16];
+		let shard_script = ShardsScriptInfo {
+			format: ShardsFormat::Edn,
+			requiring: vec![shard_script_num_1],
+			implementing: vec![shard_script_num_2, shard_script_num_3],
+		};
+
+		let proto_shard_script_2 = ProtoFragment {
+			references: Vec::new(),
+			category: Categories::Shards(shard_script),
+			tags: Vec::new(),
+			linked_asset: None,
+			include_cost: Some(2),
+			data: "0x667".as_bytes().to_vec(),
+		};
+
 		let patch = Patch {
 			proto_fragment: ProtoFragment {
 				references: Vec::new(),
@@ -235,6 +270,8 @@ impl DummyData {
 			proto_fragment_third: proto_third,
 			proto_fragment_fourth: proto_fourth,
 			proto_fragment_fifth: proto_fifth,
+			proto_shard_script: proto_shard_script,
+			proto_shard_script_2: proto_shard_script_2,
 			patch,
 			metadata,
 			stake,

--- a/pallets/protos/src/lib.rs
+++ b/pallets/protos/src/lib.rs
@@ -843,9 +843,9 @@ pub mod pallet {
 					Categories::Trait(proto_shard_trait) => {
 						if let Categories::Trait(struct_proto_shard_trait) = &struct_proto.category {
 							// search by trait name (the ID must be all zeros)
-							if (proto_shard_trait.id == [0u8; 16] && proto_shard_trait.name == struct_proto_shard_trait.name) || 
+							if (proto_shard_trait.name == struct_proto_shard_trait.name) || 
 								// search by trait id (the name must be empty)
-								(proto_shard_trait.name.is_empty() && proto_shard_trait.id == struct_proto_shard_trait.id) || 
+								(proto_shard_trait.id == struct_proto_shard_trait.id) || 
 								// search by full match of trait info
 								(proto_shard_trait == struct_proto_shard_trait)
 							{
@@ -916,8 +916,8 @@ pub mod pallet {
 						if let Categories::Trait(stored_shard_trait) = &category { 
 						
 							// search by trait name (the ID must be all zeros)
-							if (param_shard_trait.id == [0u8; 16] && param_shard_trait.name == stored_shard_trait.name) || 
-									(param_shard_trait.name.is_empty() && param_shard_trait.id == stored_shard_trait.id)
+							if (param_shard_trait.name == stored_shard_trait.name) || 
+									(param_shard_trait.id == stored_shard_trait.id)
 							{
 								// OK. Found the category matching name OR id.
 								return true;

--- a/pallets/protos/src/lib.rs
+++ b/pallets/protos/src/lib.rs
@@ -859,6 +859,24 @@ pub mod pallet {
 							return false
 						}
 					},
+					Some(Categories::Shards(param_script_info)) => {
+						if let Categories::Shards(stored_script_info) = &struct_proto.category {
+							
+							let implementing_diffs: Vec<_> = param_script_info.implementing.clone().into_iter().filter(|item| stored_script_info.implementing.contains(item)).collect();
+							let requiring_diffs: Vec<_> = param_script_info.requiring.clone().into_iter().filter(|item| stored_script_info.requiring.contains(item)).collect();
+
+							if !implementing_diffs.is_empty() || !requiring_diffs.is_empty() || (param_script_info.format == stored_script_info.format) || (param_script_info == stored_script_info)
+							{
+								return Self::filter_tags(tags, struct_proto)
+							}
+							else {
+								return false
+							}
+						} else {
+							// it should never go here
+							return false
+						}
+					},
 					_ => {
 						if categories.into_iter().any(|cat| *cat == struct_proto.category) {
 							return Self::filter_tags(tags, struct_proto)
@@ -971,11 +989,14 @@ pub mod pallet {
 							},
 							Some(Categories::Shards(param_script_info)) => {
 								if let Categories::Shards(stored_script_info) = &category {
-									if (param_script_info.implementing == stored_script_info.implementing) || 
-											(param_script_info.requiring == stored_script_info.requiring) || 
-												(param_script_info.format == stored_script_info.format) {
-													// OK. Found the category matching a shard script info. Keep this structure and do nothing here.
-												}
+									
+									let implementing_diffs: Vec<_> = param_script_info.implementing.clone().into_iter().filter(|item| stored_script_info.implementing.contains(item)).collect();
+									let requiring_diffs: Vec<_> = param_script_info.requiring.clone().into_iter().filter(|item| stored_script_info.requiring.contains(item)).collect();
+
+									if !implementing_diffs.is_empty() || !requiring_diffs.is_empty() || (param_script_info.format == stored_script_info.format) || (param_script_info == stored_script_info)
+									{
+										// OK. Found the category matching a shard script info. Keep this structure and do nothing here.
+									}
 								}
 							},
 							// for all other types of Categories

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -3,8 +3,6 @@ use crate::{dummy_data::*, mock, mock::*, *};
 use codec::Compact;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchResult, traits::Get};
 use std::collections::BTreeMap;
-use sp_io::hashing::blake2_256;
-
 use stake_tests::stake_;
 use upload_tests::upload;
 
@@ -287,7 +285,7 @@ use upload_tests::upload;
 				"include_cost": Some(proto.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				},
 			}}).to_string();
 
@@ -334,7 +332,7 @@ use upload_tests::upload;
 				"include_cost": Some(proto.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				},
 			}}).to_string();
 
@@ -383,7 +381,7 @@ use upload_tests::upload;
 				"include_cost": Some(proto.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				},
 			}}).to_string();
 
@@ -433,7 +431,161 @@ use upload_tests::upload;
 				"include_cost": Some(proto2.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
+				},
+			}}).to_string();
+			
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_searching_by_multiple_categories_same_owner_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			// Two protos with different trait names
+			let proto1 = dd.proto_fragment_third;
+			let proto_text = dd.proto_fragment_second;
+			let proto_shard_script = dd.proto_shard_script;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id, &proto_text));
+			assert_ok!(upload(dd.account_id, &proto_shard_script));
+
+			// SEARCH
+			let num: [u8; 16] = [0u8; 16];
+			let shard = ShardsTraitInfo {
+				name: "Shards1".to_string(), // proto_fragment_fourth
+				description: "test 1".to_string(), // this description is different from the proto stored (i.e. test 1)
+				id: num,
+			};
+			let shard_script_num_1: [u8; 16] = [4u8; 16];
+			let shard_script_num_2: [u8; 16] = [5u8; 16];
+			let shard_script = ShardsScriptInfo {
+				format: ShardsFormat::Binary,
+				requiring: vec![shard_script_num_1],
+				implementing: vec![shard_script_num_2],
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 10,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Trait(shard), Categories::Shards(shard_script), Categories::Text(TextCategories::Plain)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+
+			let proto_hash = proto1.get_proto_hash();
+			let encoded = hex::encode(&proto_hash);
+
+			let proto_hash_2 = proto_shard_script.get_proto_hash();
+			let encoded2 = hex::encode(&proto_hash_2);
+
+			let proto_hash_text = proto_text.get_proto_hash();
+			let encoded3 = hex::encode(&proto_hash_text);
+			
+			let json_expected = json!({
+				encoded: {
+				"include_cost": Some(proto1.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id)
+				},
+			}, encoded2: {
+				"include_cost": Some(proto_shard_script.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id)
+				},
+			}, encoded3: {
+				"include_cost": Some(proto_text.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id)
+				},
+			}}).to_string();
+			
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_searching_by_multiple_categories_different_owner_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			// Two protos with different trait names
+			let proto1 = dd.proto_fragment_third;
+			let proto_text = dd.proto_fragment_second;
+			let proto_shard_script = dd.proto_shard_script;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id_second, &proto_text));
+			assert_ok!(upload(dd.account_id, &proto_shard_script));
+
+			// SEARCH
+			let num: [u8; 16] = [0u8; 16];
+			let shard = ShardsTraitInfo {
+				name: "Shards1".to_string(), // proto_fragment_fourth
+				description: "test 1".to_string(), // this description is different from the proto stored (i.e. test 1)
+				id: num,
+			};
+			let shard_script_num_1: [u8; 16] = [4u8; 16];
+			let shard_script_num_2: [u8; 16] = [5u8; 16];
+			let shard_script = ShardsScriptInfo {
+				format: ShardsFormat::Binary,
+				requiring: vec![shard_script_num_1],
+				implementing: vec![shard_script_num_2],
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 10,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Trait(shard), Categories::Shards(shard_script), Categories::Text(TextCategories::Plain)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+
+			let proto_hash = proto1.get_proto_hash();
+			let encoded = hex::encode(&proto_hash);
+
+			let proto_hash_2 = proto_shard_script.get_proto_hash();
+			let encoded2 = hex::encode(&proto_hash_2);
+
+			let proto_hash_text = proto_text.get_proto_hash();
+			let encoded3 = hex::encode(&proto_hash_text);
+			
+			let json_expected = json!({
+				encoded: {
+				"include_cost": Some(proto1.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id)
+				},
+			}, encoded2: {
+				"include_cost": Some(proto_shard_script.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id)
+				},
+			}, encoded3: {
+				"include_cost": Some(proto_text.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": hex::encode(dd.account_id_second)
 				},
 			}}).to_string();
 			
@@ -484,12 +636,12 @@ use upload_tests::upload;
 				"include_cost": Some(proto.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				}}, encoded2: {
 					"include_cost": Some(proto2.include_cost),
 					"owner": {
 						"type": "internal",
-						"value": "0101010101010101010101010101010101010101010101010101010101010101"
+						"value": hex::encode(dd.account_id)
 					},
 			}}).to_string();
 
@@ -540,7 +692,7 @@ use upload_tests::upload;
 				"include_cost": Some(proto_shard_script.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				},
 			}}).to_string();
 			
@@ -631,7 +783,7 @@ use upload_tests::upload;
 				"include_cost": Some(proto_shard_script.include_cost),
 				"owner": {
 					"type": "internal",
-					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+					"value": hex::encode(dd.account_id)
 				},
 			}}).to_string();
 			

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -214,7 +214,8 @@ mod upload_tests {
 
 mod get_protos_tests {
 	use super::*;
-	use upload_tests::upload;
+	use protos::categories::{ShardsScriptInfo, ShardsFormat};
+use upload_tests::upload;
 
 	#[test]
 	fn get_protos_should_not_work_if_owner_not_exists() {
@@ -492,6 +493,148 @@ mod get_protos_tests {
 					},
 			}}).to_string();
 
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_shards_script_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			// Two protos with different trait names
+			let proto1 = dd.proto_fragment_third;
+			let proto_shard_script = dd.proto_shard_script;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id, &proto_shard_script));
+
+			// SEARCH
+			let shard_script_num_1: [u8; 16] = [4u8; 16];
+			let shard_script_num_2: [u8; 16] = [5u8; 16];
+			let shard_script = ShardsScriptInfo {
+				format: ShardsFormat::Binary,
+				requiring: vec![shard_script_num_1],
+				implementing: vec![shard_script_num_2],
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Shards(shard_script)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+
+			let proto_hash = proto_shard_script.get_proto_hash();
+			let encoded = hex::encode(&proto_hash);
+			
+			let json_expected = json!({
+				encoded: {
+				"include_cost": Some(proto_shard_script.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+				},
+			}}).to_string();
+			
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_shards_script_should_not_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			// Two protos with different trait names
+			let proto1 = dd.proto_fragment_third;
+			let proto_shard_script = dd.proto_shard_script;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id, &proto_shard_script));
+
+			// SEARCH
+			let shard_script_num_1: [u8; 16] = [0u8; 16];
+			let shard_script_num_2: [u8; 16] = [1u8; 16];
+			let shard_script = ShardsScriptInfo {
+				format: ShardsFormat::Binary,
+				requiring: vec![shard_script_num_1],
+				implementing: vec![shard_script_num_2],
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Shards(shard_script)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			let json_expected = json!({}).to_string();
+			
+			assert_eq!(result_string, json_expected);
+		});
+	}
+
+	#[test]
+	fn get_protos_by_partial_implementing_shards_script_should_work() {
+		new_test_ext().execute_with(|| {
+			// UPLOAD
+			let dd = DummyData::new();
+			let proto1 = dd.proto_fragment_third;
+			let proto_shard_script = dd.proto_shard_script_2;
+
+			assert_ok!(upload(dd.account_id, &proto1));
+			assert_ok!(upload(dd.account_id, &proto_shard_script));
+
+			// SEARCH
+			let shard_script_num_1: [u8; 16] = [0u8; 16];
+			let shard_script_num_2: [u8; 16] = [5u8; 16];
+			let shard_script = ShardsScriptInfo {
+				format: ShardsFormat::Binary,
+				requiring: vec![shard_script_num_1],
+				implementing: vec![shard_script_num_2],
+			};
+			let params = GetProtosParams {
+				desc: true,
+				from: 0,
+				limit: 2,
+				metadata_keys: Vec::new(),
+				owner: None,
+				return_owners: true,
+				categories: vec![Categories::Shards(shard_script)],
+				tags: Vec::new(),
+				available: Some(true),
+			};
+
+			let result = ProtosPallet::get_protos(params).ok().unwrap();
+			let result_string = std::str::from_utf8(&result).unwrap();
+			
+			let proto_hash = proto_shard_script.get_proto_hash();
+			let encoded = hex::encode(&proto_hash);
+			
+			let json_expected = json!({
+				encoded: {
+				"include_cost": Some(proto_shard_script.include_cost),
+				"owner": {
+					"type": "internal",
+					"value": "0101010101010101010101010101010101010101010101010101010101010101"
+				},
+			}}).to_string();
+			
 			assert_eq!(result_string, json_expected);
 		});
 	}

--- a/rpc/index.js
+++ b/rpc/index.js
@@ -78,13 +78,32 @@ const connectToLocalNode = async () => {
                 ]
             },
 
-            ShardsTrait: "Compact<u32>",
+            ShardsTraitInfo: {
+                name: 'String',
+                description: 'String',
+                id: 'ShardsTrait'
+            },
+
+            ShardsScriptInfo: {
+                format: 'ShardsFormat',
+                requiring: 'Vec<ShardsTrait>',
+                implementing: 'Vec<ShardsTrait>'
+            },
+
+            ShardsTrait: "Vec<u32>",
+
+            ShardsFormat: {
+                _enum: [
+                    "edn",
+                    "binary",
+                ]
+            },
 
             Categories: {
                 _enum: {
                     "text": "TextCategories",
-                    "trait": "(Vec<u32>, Vec<u32>, ShardsTrait)",
-                    "shards": "(ShardsFormat, Vec<ShardsTrait>)",
+                    "trait": "ShardsTraitInfo",
+                    "shards": "ShardsScriptInfo",
                     "audio": "AudioCategories",
                     "texture": "TextureCategories",
                     "vector": "VectorCategories",

--- a/rpc/test/protosTest.js
+++ b/rpc/test/protosTest.js
@@ -61,6 +61,22 @@ describe('Protos RPCs', () => {
 
         });
 
+        it('should return no protos when filtering for not existing Category Trait', async () => {
+
+            let result = await api.rpc.protos.getProtos(api.createType("GetProtosParams", { desc: true, from: 0, limit: 10, categories: [{ "trait": {name: "ciao", description: "this is good", id: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]} }] }))
+
+            assert(result.toHuman() === "{}")
+
+        });
+
+        it('should return no protos when filtering for not existing Category Shards', async () => {
+
+            let result = await api.rpc.protos.getProtos(api.createType("GetProtosParams", { desc: true, from: 0, limit: 10, categories: [{ "shards": {format: "edn", requiring: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], implementing: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]} }] }))
+
+            assert(result.toHuman() === "{}")
+
+        });
+
         it('should return correct owner', async () => {
 
             const params = api.createType("GetProtosParams", {


### PR DESCRIPTION
This makes it possible to get protos by filtering on `ShardsScriptInfo`. 
It matches either by all fields - as it was implemented before -, or by any single field. Regarding the fields `implementing` and `requiring`, it also match with a subset of items contained in the vectors. This allows users to search protos by subsets of shards scripts.