### PR TITLE
Able to Retrieve Proto-Fragments that do not have Certain Tags

### DIFF
--- a/pallets/protos/rpc/src/lib.rs
+++ b/pallets/protos/rpc/src/lib.rs
@@ -67,6 +67,7 @@ where
 			return_owners: params.return_owners,
 			categories: params.categories,
 			tags: params.tags.into_iter().map(|s| s.into_bytes()).collect(),
+			exclude_tags: params.exclude_tags,
 			available: params.available,
 		};
 

--- a/pallets/protos/src/lib.rs
+++ b/pallets/protos/src/lib.rs
@@ -86,6 +86,8 @@ pub struct GetProtosParams<TAccountId, TString> {
 	pub return_owners: bool,
 	pub categories: Vec<Categories>,
 	pub tags: Vec<TString>,
+	/// The returned Proto-Fragments must not have any tag that is specified in the `tags` field
+	pub exclude_tags: bool,
 	pub available: Option<bool>,
 }
 
@@ -893,6 +895,7 @@ pub mod pallet {
 			tags: &[Vec<u8>],
 			categories: &[Categories],
 			avail: Option<bool>,
+			exclude_tags: bool,
 		) -> bool {
 			if let Some(struct_proto) = <Protos<T>>::get(proto_id) {
 				if let Some(avail) = avail {
@@ -904,9 +907,9 @@ pub mod pallet {
 				}
 
 				if categories.len() == 0 {
-					return Self::filter_tags(tags, &struct_proto);
+					return Self::filter_tags(tags, &struct_proto, exclude_tags);
 				} else {
-					return Self::filter_category(tags, &struct_proto, categories);
+					return Self::filter_category(tags, &struct_proto, categories, exclude_tags);
 				}
 			} else {
 				false
@@ -917,6 +920,7 @@ pub mod pallet {
 			tags: &[Vec<u8>],
 			struct_proto: &Proto<T::AccountId, T::BlockNumber>,
 			categories: &[Categories],
+			exclude_tags: bool,
 		) -> bool {
 			let found: Vec<_> = categories
 				.into_iter()
@@ -941,7 +945,7 @@ pub mod pallet {
 								== stored_script_info.format) || (param_script_info
 								== stored_script_info)
 							{
-								return Self::filter_tags(tags, struct_proto);
+								return Self::filter_tags(tags, struct_proto, exclude_tags);
 							} else {
 								return false;
 							}
@@ -952,7 +956,7 @@ pub mod pallet {
 					},
 					_ => {
 						if *cat == &struct_proto.category {
-							return Self::filter_tags(tags, struct_proto);
+							return Self::filter_tags(tags, struct_proto, exclude_tags);
 						} else {
 							return false;
 						}
@@ -970,6 +974,7 @@ pub mod pallet {
 		fn filter_tags(
 			tags: &[Vec<u8>],
 			struct_proto: &Proto<T::AccountId, T::BlockNumber>,
+			exclude_tags: bool,
 		) -> bool {
 			if tags.len() == 0 {
 				true
@@ -977,7 +982,11 @@ pub mod pallet {
 				tags.into_iter().all(|tag| {
 					let tag_idx = <Tags<T>>::get(tag);
 					if let Some(tag_idx) = tag_idx {
-						struct_proto.tags.contains(&Compact::from(tag_idx))
+						if struct_proto.tags.contains(&Compact::from(tag_idx)) {
+							!exclude_tags
+						} else {
+							exclude_tags
+						}
 					} else {
 						false
 					}
@@ -1069,6 +1078,7 @@ pub mod pallet {
 									&params.tags,
 									&params.categories,
 									params.available,
+									params.exclude_tags
 								)
 							})
 							.skip(params.from as usize)
@@ -1084,6 +1094,7 @@ pub mod pallet {
 									&params.tags,
 									&params.categories,
 									params.available,
+									params.exclude_tags
 								)
 							})
 							.skip(params.from as usize)
@@ -1127,6 +1138,7 @@ pub mod pallet {
 										&params.tags,
 										&params.categories,
 										params.available,
+										params.exclude_tags
 									)
 								})
 								.collect()
@@ -1140,6 +1152,7 @@ pub mod pallet {
 										&params.tags,
 										&params.categories,
 										params.available,
+										params.exclude_tags
 									)
 								})
 								.collect()

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -243,6 +243,7 @@ mod get_protos_tests {
 				return_owners: false,
 				categories: vec![Categories::Trait(Some(twox_64(&proto.data)))],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -272,6 +273,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Text(TextCategories::Plain)],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -314,6 +316,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Trait(Some(twox_64(&proto.data)))],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -358,6 +361,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Trait(Some(twox_64(&proto.data)))],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -403,6 +407,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Trait(Some(twox_64(&proto2.data)))],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -461,6 +466,7 @@ mod get_protos_tests {
 					Categories::Text(TextCategories::Plain),
 				],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -537,6 +543,7 @@ mod get_protos_tests {
 					Categories::Text(TextCategories::Plain),
 				],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -602,6 +609,7 @@ mod get_protos_tests {
 					Categories::Trait(Some(twox_64(&proto2.data))),
 				],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -661,6 +669,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Shards(shard_script)],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -713,6 +722,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Shards(shard_script)],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -753,6 +763,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Shards(shard_script)],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -542,6 +542,7 @@ mod get_protos_tests {
 					Categories::Shards(shard_script),
 				],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 
@@ -870,6 +871,7 @@ mod get_protos_tests {
 				return_owners: true,
 				categories: vec![Categories::Shards(shard_script)],
 				tags: Vec::new(),
+				exclude_tags: false,
 				available: Some(true),
 			};
 

--- a/rpc/index.js
+++ b/rpc/index.js
@@ -118,6 +118,7 @@ const connectToLocalNode = async () => {
                 return_owners: 'bool',
                 categories: 'Vec<Categories>',
                 tags: 'Vec<String>',
+                exclude_tags: 'bool',
                 available: 'Option<bool>',
             }
 


### PR DESCRIPTION
`getProtos()` RPC can be used to Retrieve Proto-Fragments that do not have **certain specified Tags**