### PR TITLE
Add Code Coverage CI for Clamor

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Check Set-Up & Build
+name: CI
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,3 +73,9 @@ jobs:
       - name: Check if Rustdocs Builds
         run: |
           cargo doc
+          
+      - name: Push to codecov.io
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out Xml
+          bash <(curl -s https://codecov.io/bash) -X gcov -t $CODECOV_TOKEN

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Clamor
 
+[![license](https://img.shields.io/github/license/fragcolor-xyz/clamor)](./LICENSE)
+![CI](https://github.com/fragcolor-xyz/clamor/workflows/CI/badge.svg)
+[![codecov](https://codecov.io/gh/fragcolor-xyz/clamor/branch/devel/graph/badge.svg?token=4PMT2FQFDS)](https://codecov.io/gh/fragcolor-xyz/clamor)
+[![docs](https://img.shields.io/badge/docs-API-blueviolet)](https://fragcolor-xyz.github.io/clamor/)
+
 Clamor is a custom blockchain built on the [Substrate](https://substrate.io/) framework.
 
 It is a protocol and networking stack that enables complete on-chain storage and full synchronization of asset data (protos, fragments, chainblocks code etc.) across the blockchain nodes.


### PR DESCRIPTION
**Pushes the XML file (from doing `cargo tarpaulin --out Xml`) to CodeCov.**

Footnote: I think having code coverage will be very useful since it'll allow us to see exactly which extrinsic / part of the extrinsic we have not tested yet

Footnote 2: Followed https://eipi.xyz/blog/rust-code-coverage-with-github-workflows/#coveralls-io-using-official-github-action