### PR TITLE
Move NOVA unit specifications in chain_spec (#171)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "3.0", features = ["derive"] }
 sp-clamor = { version = '0.1.0', path = '../primitives/clamor' }
 hex = { version = "0.4.3", default-features = false }
 protos = { version = "0.1.16", default-features = false }
+serde_json = { version = '1.0.79', default-features = false, features = ['alloc'] }
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/fragcolor-xyz/substrate.git'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -21,6 +21,7 @@ use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{ecdsa, ed25519, sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
+use serde_json;
 
 /// TODO: Documentation
 pub type UploadId = ecdsa::Public;
@@ -75,6 +76,17 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId, UploadId, EthId,
 	)
 }
 
+fn chain_spec_properties() -> serde_json::map::Map<String, serde_json::Value> {
+	serde_json::json!({
+		"ss58Format": 93,
+		"tokenDecimals": 12,
+		"tokenSymbol": "NOVA"
+	})
+		.as_object()
+		.expect("Map given; qed")
+		.clone()
+}
+
 /// Returns the `ChainSpec` struct used when for starting/joining a Clamor Development Network
 pub fn development_config() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
@@ -111,7 +123,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 		None,
 		None,
 		// Properties
-		None,
+		Some(chain_spec_properties()),
 		// Extensions
 		None,
 	))
@@ -160,7 +172,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 		None,
 		None,
 		// Properties
-		None,
+		Some(chain_spec_properties()),
 		// Extensions
 		None,
 	))
@@ -201,7 +213,7 @@ pub fn live_config() -> Result<ChainSpec, String> {
 		None,
 		None,
 		// Properties
-		None,
+		Some(chain_spec_properties()),
 		// Extensions
 		None,
 	))

--- a/testnet.json
+++ b/testnet.json
@@ -7,11 +7,7 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": "frag",
-  "properties": {
-    "ss58Format": 93,
-    "tokenDecimals": 12,
-    "tokenSymbol": "NOVA"
-  },
+  "properties": {},
   "codeSubstitutes": {},
   "genesis": {
     "runtime": {


### PR DESCRIPTION
Move NOVA unit specifications from `testnet.json` to `chain_spec.rs`.