### PR TITLE
Only Build Clamor Once in the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Check if Clamor Builds
         run: |
-          RUSTFLAGS="-D missing-docs" cargo build
+          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks
           
       - name: Check if all the Polkadot.js RPC tests pass
         run: |
@@ -58,10 +58,6 @@ jobs:
           RUST_LOG=bitswap=trace target/debug/clamor --dev --tmp --rpc-external --rpc-port 9933 --rpc-cors all --ws-external --enable-offchain-indexing 1 --rpc-methods=Unsafe --ipfs-server &
           docker run --rm --user root --network host -v ${{ github.workspace }}:/data chainblocks/shards sh /data/shards/run.sh
           kill %1
-
-      - name: Check Build for Benchmarking
-        run: |
-          cargo check --features=runtime-benchmarks
 
       - name: Check if all Tests Pass
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check if Clamor Builds
         run: |
-          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks
+          RUSTFLAGS="-D missing-docs" cargo build --features runtime-benchmarks
 
       - name: Check if all the Polkadot.js RPC tests pass
         run: |
@@ -68,13 +68,6 @@ jobs:
         run: |
           cargo doc --no-deps
 
-
-  check_code_coverage:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
       - name: Push to codecov.io
         run: |
           cargo install cargo-tarpaulin

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Check if Clamor Builds
         run: |
-          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks
+          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks --tests
           
       - name: Check if all the Polkadot.js RPC tests pass
         run: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Check if Rustdoc Builds
         run: |
-          cargo doc
+          cargo doc --no-deps
           
       - name: Push to codecov.io
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,11 +37,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14'  # The node-version input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.
-          
+
       - name: Check if Clamor Builds
         run: |
-          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks --tests
-          
+          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks --lib --bins --tests
+
       - name: Check if all the Polkadot.js RPC tests pass
         run: |
           RUST_LOG=bitswap=trace target/debug/clamor --dev --tmp --rpc-external --rpc-port 9933 --rpc-cors all --ws-external --enable-offchain-indexing 1 --rpc-methods=Unsafe --ipfs-server &
@@ -67,7 +67,7 @@ jobs:
       - name: Check if Rustdoc Builds
         run: |
           cargo doc --no-deps
-          
+
       - name: Push to codecov.io
         run: |
           cargo install cargo-tarpaulin

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,17 +59,14 @@ jobs:
           docker run --rm --user root --network host -v ${{ github.workspace }}:/data chainblocks/shards sh /data/shards/run.sh
           kill %1
 
-      - name: Check if all Tests Pass
+      - name: Check if Tests Pass and Push to Codecov.io
         run: |
-          cargo test --no-fail-fast
+          # cargo test --no-fail-fast
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out Xml
+          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"
 
 
       - name: Check if Rustdoc Builds
         run: |
           cargo doc --no-deps
-
-      - name: Push to codecov.io
-        run: |
-          cargo install cargo-tarpaulin
-          cargo tarpaulin --out Xml
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check if Clamor Builds
         run: |
-          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks --lib --bins --tests
+          RUSTFLAGS="-D missing-docs" cargo build --features=runtime-benchmarks
 
       - name: Check if all the Polkadot.js RPC tests pass
         run: |
@@ -68,6 +68,13 @@ jobs:
         run: |
           cargo doc --no-deps
 
+
+  check_code_coverage:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
       - name: Push to codecov.io
         run: |
           cargo install cargo-tarpaulin

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,9 +17,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup
+      - name: Install the Necessary Packages
         run: |
           sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 
@@ -37,10 +37,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14'  # The node-version input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.
-
-      - name: Test RPCs
+          
+      - name: Check if Clamor Builds
         run: |
-          cargo build
+          RUSTFLAGS="-D missing-docs" cargo build
+          
+      - name: Check if all the Polkadot.js RPC tests pass
+        run: |
           RUST_LOG=bitswap=trace target/debug/clamor --dev --tmp --rpc-external --rpc-port 9933 --rpc-cors all --ws-external --enable-offchain-indexing 1 --rpc-methods=Unsafe --ipfs-server &
           sleep 10
           docker run --rm --user root --network host -v ${{ github.workspace }}:/data chainblocks/shards shards /data/shards/test-protos-rpc.edn
@@ -52,25 +55,20 @@ jobs:
 
       - name: Run IPFS Test
         run: |
-          cargo build
           RUST_LOG=bitswap=trace target/debug/clamor --dev --tmp --rpc-external --rpc-port 9933 --rpc-cors all --ws-external --enable-offchain-indexing 1 --rpc-methods=Unsafe --ipfs-server &
           docker run --rm --user root --network host -v ${{ github.workspace }}:/data chainblocks/shards sh /data/shards/run.sh
           kill %1
-
-      - name: Check Build
-        run: |
-          RUSTFLAGS="-D missing-docs" cargo check
 
       - name: Check Build for Benchmarking
         run: |
           cargo check --features=runtime-benchmarks
 
-      - name: Check Test
+      - name: Check if all Tests Pass
         run: |
           cargo test --no-fail-fast
 
 
-      - name: Check if Rustdocs Builds
+      - name: Check if Rustdoc Builds
         run: |
           cargo doc
           
@@ -78,4 +76,4 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml
-          bash <(curl -s https://codecov.io/bash) -X gcov -t $CODECOV_TOKEN
+          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.f.info || echo "Codecov did not collect coverage reports"

--- a/pallets/detach/src/mock.rs
+++ b/pallets/detach/src/mock.rs
@@ -93,3 +93,13 @@ impl pallet_detach::Config for Test {
 	type WeightInfo = ();
 	type AuthorityId = pallet_detach::crypto::DetachAuthId;
 }
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+
+	ext.execute_with(|| System::set_block_number(1)); // if we don't execute this line, Events are not emitted from extrinsics (I don't know why this is the case though)
+
+	ext
+}

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -9,11 +9,6 @@ use upload_tests::upload;
 use copied_from_pallet_accounts::{link_, lock_};
 use protos::categories::TextCategories;
 
-#[test]
-pub fn dummy_test_function() {
-	assert!(false);
-}
-
 mod copied_from_pallet_accounts {
 	use super::*;
 

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -9,6 +9,11 @@ use upload_tests::upload;
 use copied_from_pallet_accounts::{link_, lock_};
 use protos::categories::TextCategories;
 
+#[test]
+pub fn dummy_test_function() {
+	assert!(false);
+}
+
 mod copied_from_pallet_accounts {
 	use super::*;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3,7 +3,8 @@
 //! The runtime for a Substrate node contains all of the business logic
 //! for executing transactions, saving state transitions, and interacting with the outer node.
 
-#![warn(missing_docs)]
+// Some of the Substrate Macros in this file throw missing_docs warnings. That's why we allow this file to have missing_docs.
+#![allow(missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.


### PR DESCRIPTION
This saves time since we are currently building Clamor 2.5 times (2 `cargo build`s and 1 `cargo check`)