### PR TITLE
Rollback to substrate tag fragnova-v0.0.6

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		{{~#each benchmark.components as |c| ~}}
 		{{~#if (not c.is_used)}}_{{/if}}{{c.name}}: u32, {{/each~}}
 	) -> Weight {
-		Weight::from_ref_time({{underscore benchmark.base_weight}} as u64)
+		({{underscore benchmark.base_weight}} as u64)
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
-			.saturating_add(Weight::from_ref_time({{underscore cw.slope}} as u64).saturating_mul({{cw.name}} as u64))
+			.saturating_add(({{underscore cw.slope}} as u64).saturating_mul({{cw.name}} as u64))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
 			.saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}} as u64))
@@ -99,10 +99,10 @@ impl WeightInfo for () {
 		{{~#each benchmark.components as |c| ~}}
 		{{~#if (not c.is_used)}}_{{/if}}{{c.name}}: u32, {{/each~}}
 	) -> Weight {
-		Weight::from_ref_time({{underscore benchmark.base_weight}} as u64)
+		({{underscore benchmark.base_weight}} as u64)
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
-			.saturating_add(Weight::from_ref_time({{underscore cw.slope}} as u64).saturating_mul({{cw.name}} as u64))
+			.saturating_add(({{underscore cw.slope}} as u64).saturating_mul({{cw.name}} as u64))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
 			.saturating_add(RocksDbWeight::get().reads({{benchmark.base_reads}} as u64))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug 0.3.0",
 ]
@@ -56,7 +56,7 @@ checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.3.0",
  "ctr",
  "ghash",
  "subtle",
@@ -116,16 +116,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-bytes"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "arrayvec"
@@ -147,11 +150,11 @@ checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "async-channel"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "event-listener",
  "futures-core",
 ]
@@ -164,7 +167,7 @@ checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
  "async-lock",
  "async-task",
- "concurrent-queue 2.0.0",
+ "concurrent-queue",
  "fastrand",
  "futures-lite",
  "slab",
@@ -187,13 +190,13 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
@@ -202,7 +205,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -217,20 +220,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
 dependencies = [
  "async-io",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
  "futures-lite",
  "libc",
- "once_cell",
  "signal-hook",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -262,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "async-std-resolver"
-version = "0.22.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba50e24d9ee0a8950d3d03fc6d0dd10aa14b5de3b101949b4e160f7fee7c723"
+checksum = "0f2f8a4a203be3325981310ab243a28e6e4ea55b6519bffce05d41ab60e09ad8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -283,9 +286,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -317,7 +320,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -339,7 +342,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide 0.5.4",
- "object",
+ "object 0.29.0",
  "rustc-demangle",
 ]
 
@@ -368,12 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
-
-[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +378,12 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
 
 [[package]]
 name = "bincode"
@@ -393,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -450,6 +453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq 0.1.5",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895adc16c8b3273fbbc32685a7d55227705eda08c01e77704020f3491924b44b"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
@@ -525,16 +538,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
 dependencies = [
  "async-channel",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -603,12 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
 name = "camino"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,25 +665,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-expr"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
@@ -685,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
 ]
@@ -698,7 +690,7 @@ checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.3.0",
  "poly1305",
  "zeroize",
 ]
@@ -741,6 +733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clamor"
 version = "4.0.0-dev"
 dependencies = [
@@ -752,7 +754,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "log",
- "pallet-contracts-primitives",
+ "pallet-contracts-rpc",
  "pallet-fragments-rpc",
  "pallet-protos-rpc",
  "pallet-transaction-payment-rpc",
@@ -807,6 +809,7 @@ dependencies = [
  "pallet-balances",
  "pallet-contracts",
  "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-detach",
  "pallet-fragments",
  "pallet-fragments-rpc-runtime-api",
@@ -849,29 +852,31 @@ checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
 name = "clap"
-version = "4.0.27"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "is-terminal",
+ "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -882,11 +887,20 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -912,15 +926,6 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
-]
-
-[[package]]
-name = "concurrent-queue"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
@@ -930,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "constant_time_eq"
@@ -991,21 +996,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52056f6d0584484b57fa6c1a65c1fcb15f3780d8b6a758426d9e3084169b2ddd"
+checksum = "749d0d6022c9038dccf480bdde2a38d435937335bf2bb0f14e815d94517cdce8"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fed94c8770dc25d01154c3ffa64ed0b3ba9d583736f305fed7beebe5d9cf74"
+checksum = "e94370cc7b37bf652ccd8bb8f09bd900997f7ccf97520edfc75554bb5c4abbea"
 dependencies = [
- "arrayvec 0.7.2",
- "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -1020,33 +1023,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c451b81faf237d11c7e4f3165eeb6bac61112762c5cfe7b4c0fb7241474358f"
+checksum = "e0a3cea8fdab90e44018c5b9a1dfd460d8ee265ac354337150222a354628bdb6"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c940133198426d26128f08be2b40b0bd117b84771fd36798969c4d712d81fc"
+checksum = "5ac72f76f2698598951ab26d8c96eaa854810e693e7dd52523958b5909fde6b2"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
+checksum = "09eaeacfcd2356fe0e66b295e8f9d59fdd1ac3ace53ba50de14d628ec902f72d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
+checksum = "dba69c9980d5ffd62c18a2bde927855fcd7c8dc92f29feaf8636052662cbd99c"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1056,15 +1059,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2629a569fae540f16a76b70afcc87ad7decb38dc28fa6c648ac73b51e78470"
+checksum = "d2920dc1e05cac40304456ed3301fde2c09bd6a9b0210bcfa2f101398d628d5b"
 
 [[package]]
 name = "cranelift-native"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20937dab4e14d3e225c5adfc9c7106bafd4ac669bdb43027b911ff794c6fb318"
+checksum = "f04dfa45f9b2a6f587c564d6b63388e00cd6589d2df6ea2758cf79e1a13285e6"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1073,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.88.2"
+version = "0.85.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fc2288957a94fd342a015811479de1837850924166d1f1856d8406e6f3609b"
+checksum = "31a46513ae6f26f3f267d8d75b5373d555fbbd1e68681f348d99df43f747ec54"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1147,9 +1150,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.6",
  "rand_core 0.6.4",
@@ -1203,7 +1206,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1247,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1259,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1274,15 +1288,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1291,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "data-encoding-macro"
@@ -1317,12 +1331,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -1335,12 +1348,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1423,12 +1430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,9 +1470,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -1503,20 +1504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-zebra"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown",
- "hex",
- "rand_core 0.6.4",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,14 +1511,13 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.6",
  "ff",
  "generic-array 0.14.6",
  "group",
@@ -1543,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1588,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
@@ -1615,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "18.0.0"
+version = "17.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+checksum = "e4966fba78396ff92db3b817ee71143eccd98acf0f876b8d600e585a670c5d1b"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1625,11 +1611,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethereum-types"
-version = "0.14.0"
+name = "ethbloom"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom",
  "fixed-hash",
  "primitive-types",
  "uint",
@@ -1682,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1730,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1758,15 +1756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,7 +1764,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
 ]
@@ -1790,12 +1779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
 name = "fragments"
 version = "0.1.0"
 source = "git+https://github.com/fragcolor-xyz/fragments.git#d13886e62c362d777e26760d6592b3d111f2bd82"
@@ -1807,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1819,7 +1802,6 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-application-crypto",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
@@ -1830,10 +1812,9 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "Inflector",
- "array-bytes",
  "chrono",
  "clap",
  "comfy-table",
@@ -1843,6 +1824,7 @@ dependencies = [
  "gethostname",
  "handlebars",
  "hash-db",
+ "hex",
  "itertools",
  "kvdb",
  "lazy_static",
@@ -1871,7 +1853,6 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-storage",
  "sp-trie",
  "tempfile",
@@ -1882,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1910,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1935,19 +1916,16 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-weights",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "Inflector",
- "cfg-expr",
  "frame-support-procedural-tools",
- "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1956,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1968,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1978,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "log",
@@ -1990,13 +1968,12 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version",
- "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2011,10 +1988,22 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "sp-api",
+]
+
+[[package]]
+name = "fs-swap"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "libloading 0.5.2",
+ "winapi",
 ]
 
 [[package]]
@@ -2271,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2283,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -2342,6 +2331,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2365,15 +2363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2373,12 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hmac"
@@ -2403,15 +2398,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -2572,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "2.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c008e570a43c00de6aed9714035e5ea6a498c255323db9091722af6ee67dd"
+checksum = "015a7df1eb6dda30df37f34b63ada9b7b352984b0e84de2a20ed526345000791"
 dependencies = [
  "async-io",
  "core-foundation",
@@ -2599,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.4.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
  "serde",
 ]
@@ -2624,8 +2610,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -2648,19 +2643,15 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
-]
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "ip_network"
@@ -2685,18 +2676,6 @@ name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes 1.0.1",
- "rustix 0.36.3",
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "itertools"
@@ -2840,14 +2819,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sec1",
 ]
 
 [[package]]
@@ -2870,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585089ceadba0197ffe9af6740ab350b325e3c1f5fccfbc3522e0250c750409b"
+checksum = "a301d8ecb7989d4a6e2c57a49baca77d353bdbf879909debe3f375fe25d61f86"
 dependencies = [
  "parity-util-mem",
  "smallvec",
@@ -2880,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d109c87bfb7759edd2a49b2649c1afe25af785d930ad6a38479b4dc70dd873"
+checksum = "ece7e668abd21387aeb6628130a6f4c802787f014fa46bc83221448322250357"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2891,13 +2870,15 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.16.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c076cc2cdbac89b9910c853a36c957d3862a779f31c2661174222cefb49ee597"
+checksum = "ca7fbdfd71cd663dceb0faf3367a99f8cf724514933e9867cec4995b6027cbc1"
 dependencies = [
+ "fs-swap",
  "kvdb",
  "log",
  "num_cpus",
+ "owning_ref",
  "parity-util-mem",
  "parking_lot 0.12.1",
  "regex",
@@ -2919,9 +2900,19 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi",
+]
 
 [[package]]
 name = "libloading"
@@ -2941,9 +2932,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libp2p"
-version = "0.49.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
+checksum = "81327106887e42d004fbdab1fef93675be2e2e07c1b95fce45e2cc813485611d"
 dependencies = [
  "bytes",
  "futures",
@@ -2951,8 +2942,12 @@ dependencies = [
  "getrandom 0.2.8",
  "instant",
  "lazy_static",
+ "libp2p-autonat",
  "libp2p-core",
+ "libp2p-deflate",
  "libp2p-dns",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
@@ -2960,24 +2955,49 @@ dependencies = [
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
+ "libp2p-plaintext",
+ "libp2p-pnet",
+ "libp2p-relay",
+ "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-swarm-derive",
  "libp2p-tcp",
+ "libp2p-uds",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "parking_lot 0.12.1",
  "pin-project",
+ "rand 0.7.3",
  "smallvec",
 ]
 
 [[package]]
-name = "libp2p-core"
-version = "0.37.0"
+name = "libp2p-autonat"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799676bb0807c788065e57551c6527d461ad572162b0519d1958946ff9e0539d"
+checksum = "4decc51f3573653a9f4ecacb31b1b922dd20c25a6322bb15318ec04287ec46f9"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf9b94cefab7599b2d3dff2f93bee218c6621d68590b23ede4485813cbcece6"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2988,6 +3008,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "lazy_static",
+ "libsecp256k1",
  "log",
  "multiaddr",
  "multihash",
@@ -2997,6 +3018,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
+ "ring",
  "rw-stream-sink",
  "sha2 0.10.6",
  "smallvec",
@@ -3007,10 +3029,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-dns"
-version = "0.37.0"
+name = "libp2p-deflate"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
+checksum = "d0183dc2a3da1fbbf85e5b6cf51217f55b14f5daea0c455a9536eef646bfec71"
+dependencies = [
+ "flate2",
+ "futures",
+ "libp2p-core",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbf54723250fa5d521383be789bf60efdabe6bacfb443f87da261019a49b4b5"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -3022,10 +3055,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-identify"
-version = "0.40.0"
+name = "libp2p-floodsub"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
+checksum = "98a4b6ffd53e355775d24b76f583fdda54b3284806f678499b57913adb94f231"
+dependencies = [
+ "cuckoofilter",
+ "fnv",
+ "futures",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "smallvec",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b4b888cfbeb1f5551acd3aa1366e01bf88ede26cc3c4645d0d2d004d5ca7b0"
+dependencies = [
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "fnv",
+ "futures",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "regex",
+ "sha2 0.10.6",
+ "smallvec",
+ "unsigned-varint",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50b585518f8efd06f93ac2f976bd672e17cdac794644b3117edd078e96bda06"
 dependencies = [
  "asynchronous-codec",
  "futures",
@@ -3044,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.41.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6721c200e2021f6c3fab8b6cf0272ead8912d871610ee194ebd628cecf428f22"
+checksum = "740862893bb5f06ac24acc9d49bdeadc3a5e52e51818a30a25c1f3519da2c851"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
@@ -3061,7 +3140,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "rand 0.8.5",
+ "rand 0.7.3",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -3072,15 +3151,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.41.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761704e727f7d68d58d7bc2231eafae5fc1b9814de24290f126df09d4bd37a15"
+checksum = "66e5e5919509603281033fd16306c61df7a4428ce274b67af5e14b07de5cdcb2"
 dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
  "futures",
  "if-watch",
+ "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3092,23 +3172,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.10.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
+checksum = "ef8aff4a1abef42328fbb30b17c853fff9be986dc39af17ee39f9c5f755c5e0c"
 dependencies = [
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "prometheus-client",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692664acfd98652de739a8acbb0a0d670f1d67190a49be6b4395e22c37337d89"
+checksum = "61fd1b20638ec209c5075dfb2e8ce6a7ea4ec3cd3ad7b77f7a477c06d53322e2"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3117,16 +3199,16 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand 0.7.3",
  "smallvec",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.40.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048155686bd81fe6cb5efdef0c6290f25ad32a0a42e8f4f72625cf6a505a206f"
+checksum = "762408cb5d84b49a600422d7f9a42c18012d8da6ebcd570f9a4a4290ba41fb6f"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -3146,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.40.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7228b9318d34689521349a86eb39a3c3a802c9efc99a0568062ffb80913e3f91"
+checksum = "100a6934ae1dbf8a693a4e7dd1d730fd60b774dafc45688ed63b554497c6c925"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3156,15 +3238,95 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
+ "rand 0.7.3",
+ "void",
+]
+
+[[package]]
+name = "libp2p-plaintext"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be27bf0820a6238a4e06365b096d428271cce85a129cf16f2fe9eb1610c4df86"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "log",
+ "prost",
+ "prost-build",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
+name = "libp2p-pnet"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de160c5631696cea22be326c19bd9d306e254c4964945263aea10f25f6e0864e"
+dependencies = [
+ "futures",
+ "log",
+ "pin-project",
  "rand 0.8.5",
+ "salsa20",
+ "sha3",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4931547ee0cce03971ccc1733ff05bb0c4349fd89120a39e9861e2bbe18843c3"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "prost-codec",
+ "rand 0.8.5",
+ "smallvec",
+ "static_assertions",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-rendezvous"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9511c9672ba33284838e349623319c8cad2d18cfad243ae46c6b7e8a2982ea4e"
+dependencies = [
+ "asynchronous-codec",
+ "bimap",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "thiserror",
+ "unsigned-varint",
  "void",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.22.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8827af16a017b65311a410bb626205a9ad92ec0473967618425039fa5231adc1"
+checksum = "508a189e2795d892c8f5c1fa1e9e0b1845d32d7b0b249dbf7b05b18811361843"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3173,16 +3335,16 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand 0.7.3",
  "smallvec",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.40.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
+checksum = "95ac5be6c2de2d1ff3f7693fda6faf8a827b1f3e808202277783fea9f527d114"
 dependencies = [
  "either",
  "fnv",
@@ -3192,7 +3354,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.7.3",
  "smallvec",
  "thiserror",
  "void",
@@ -3200,25 +3362,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.30.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eddc4497a8b5a506013c40e8189864f9c3a00db2b25671f428ae9007f3ba32"
+checksum = "9f54a64b6957249e0ce782f8abf41d97f69330d02bf229f0672d864f0650cc76"
 dependencies = [
- "heck",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9839d96761491c6d3e238e70554b856956fca0ab60feb9de2cd08eed4473fa92"
+checksum = "8a6771dc19aa3c65d6af9a8c65222bfc8fcd446630ddca487acd161fa6096f3b"
 dependencies = [
  "async-io",
  "futures",
  "futures-timer",
  "if-watch",
+ "ipnet",
  "libc",
  "libp2p-core",
  "log",
@@ -3226,10 +3388,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-wasm-ext"
-version = "0.37.0"
+name = "libp2p-uds"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b5b8e7a73e379e47b1b77f8a82c4721e97eca01abcd18e9cd91a23ca6ce97"
+checksum = "d125e3e5f0d58f3c6ac21815b20cf4b6a88b8db9dc26368ea821838f4161fd4d"
+dependencies = [
+ "async-std",
+ "futures",
+ "libp2p-core",
+ "log",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec894790eec3c1608f8d1a8a0bdf0dbeb79ed4de2dce964222011c2896dfa05a"
 dependencies = [
  "futures",
  "js-sys",
@@ -3241,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.39.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3758ae6f89b2531a24b6d9f5776bda6a626b60a57600d7185d43dfa75ca5ecc4"
+checksum = "9808e57e81be76ff841c106b4c5974fb4d41a233a7bdd2afbf1687ac6def3818"
 dependencies = [
  "either",
  "futures",
@@ -3260,13 +3434,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.41.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6874d66543c4f7e26e3b8ca9a6bead351563a13ab4fafd43c7927f7c0d6c12"
+checksum = "c6dea686217a06072033dc025631932810e2f6ad784e4fafa42e27d311c7a81c"
 dependencies = [
  "futures",
  "libp2p-core",
- "log",
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
@@ -3274,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3382,15 +3555,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -3414,11 +3587,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.1"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3497,11 +3670,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "f6627dc657574b49d6ad27105ed671822be56e0d2547d413bfbf3e8d8fa92e7a"
 dependencies = [
- "rustix 0.36.3",
+ "libc",
 ]
 
 [[package]]
@@ -3533,20 +3706,20 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac11bb793c28fa095b7554466f53b3a60a2cd002afdac01bcf135cbd73a269"
+checksum = "6566c70c1016f525ced45d7b7f97730a2bafb037c788211d0c186ef5b2189f0a"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.12.3",
  "parity-util-mem",
 ]
 
 [[package]]
 name = "memory_units"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
 name = "merlin"
@@ -3597,31 +3770,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.3"
+name = "more-asserts"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "multiaddr"
@@ -3691,9 +3843,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
+checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
  "bytes",
  "futures",
@@ -3713,7 +3865,7 @@ dependencies = [
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
- "num-rational",
+ "num-rational 0.4.1",
  "num-traits",
  "rand 0.8.5",
  "rand_distr",
@@ -3809,14 +3961,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nohash-hasher"
@@ -3835,16 +3993,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3862,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec 0.7.2",
  "itoa",
@@ -3882,12 +4034,23 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3908,8 +4071,20 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.11.2",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -3918,9 +4093,6 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
- "crc32fast",
- "hashbrown",
- "indexmap",
  "memchr",
 ]
 
@@ -3955,6 +4127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "pallet-accounts"
 version = "0.0.1"
 dependencies = [
@@ -3986,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4000,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4016,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4031,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4046,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -4061,7 +4242,6 @@ dependencies = [
  "scale-info 2.3.0",
  "serde",
  "smallvec",
- "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4074,23 +4254,56 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "bitflags",
  "parity-scale-codec 3.2.1",
+ "scale-info 2.3.0",
+ "serde",
+ "sp-core",
+ "sp-rpc",
  "sp-runtime",
  "sp-std",
- "sp-weights",
 ]
 
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pallet-contracts-rpc"
+version = "4.0.0-dev"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
+dependencies = [
+ "jsonrpsee",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
+ "parity-scale-codec 3.2.1",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-contracts-rpc-runtime-api"
+version = "4.0.0-dev"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
+dependencies = [
+ "pallet-contracts-primitives",
+ "parity-scale-codec 3.2.1",
+ "scale-info 2.3.0",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4182,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4205,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4221,9 +4434,8 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec 3.2.1",
@@ -4238,12 +4450,11 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "parity-scale-codec 3.2.1",
  "scale-info 2.3.0",
  "sp-io",
@@ -4319,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4334,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4348,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4369,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4383,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4401,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4417,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -4427,25 +4638,23 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec 3.2.1",
  "sp-api",
  "sp-runtime",
- "sp-weights",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4460,11 +4669,11 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.2"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7511a0bec4a336b5929999d02b560d2439c993cccf98c26481484e811adc43"
+checksum = "2c8fdb726a43661fa54b43e7114e6b88b2289cae388eb3ad766d9d1754d83fce"
 dependencies = [
- "blake2",
+ "blake2-rfc",
  "crc32fast",
  "fs2",
  "hex",
@@ -4538,12 +4747,12 @@ checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
+checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.12.1",
@@ -4565,9 +4774,18 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.45.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
+checksum = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking"
@@ -4593,7 +4811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
@@ -4612,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4661,9 +4879,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4671,9 +4889,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4681,9 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4694,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
@@ -4752,16 +4970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,16 +4983,16 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
 dependencies = [
  "autocfg",
  "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4817,50 +5025,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "predicates"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4929,21 +5097,21 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
+checksum = "ac1abe0255c04d15f571427a2d1e00099016506cf3297b53853acd2b7eb87825"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.1",
+ "owning_ref",
  "prometheus-client-derive-text-encode",
 ]
 
 [[package]]
 name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4952,9 +5120,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4962,31 +5130,31 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
+checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
  "bytes",
+ "cfg-if",
+ "cmake",
  "heck",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-codec"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
+checksum = "00af1e92c33b4813cc79fda3f2dbf56af5169709be0202df730e9ebc3e4cd007"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4997,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5010,9 +5178,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",
@@ -5248,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.3.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
+checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
 dependencies = [
  "fxhash",
  "log",
@@ -5285,6 +5453,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5305,12 +5485,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
 dependencies = [
  "crypto-bigint",
- "hmac 0.12.1",
+ "hmac 0.11.0",
  "zeroize",
 ]
 
@@ -5331,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5341,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.1.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c9f5d2a0c3e2ea729ab3706d22217177770654c3ef5056b68b69d07332d3f5"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
  "winapi",
@@ -5402,6 +5582,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.33.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.5.3",
+ "libc",
+ "linux-raw-sys 0.0.42",
+ "winapi",
+]
+
+[[package]]
+name = "rustix"
 version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
@@ -5411,20 +5605,6 @@ dependencies = [
  "io-lifetimes 0.7.5",
  "libc",
  "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 1.0.1",
- "libc",
- "linux-raw-sys 0.1.3",
  "windows-sys 0.42.0",
 ]
 
@@ -5494,6 +5674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.3",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5505,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "log",
  "sp-core",
@@ -5516,7 +5705,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5539,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "sc-client-api",
@@ -5555,13 +5744,13 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
  "parity-scale-codec 3.2.1",
  "sc-chain-spec-derive",
- "sc-network-common",
+ "sc-network",
  "sc-telemetry",
  "serde",
  "serde_json",
@@ -5572,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5583,13 +5772,13 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "chrono",
  "clap",
  "fdlimit",
  "futures",
+ "hex",
  "libp2p",
  "log",
  "names",
@@ -5601,7 +5790,6 @@ dependencies = [
  "sc-client-db",
  "sc-keystore",
  "sc-network",
- "sc-network-common",
  "sc-service",
  "sc-telemetry",
  "sc-tracing",
@@ -5623,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "fnv",
  "futures",
@@ -5651,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5676,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures",
@@ -5700,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures",
@@ -5729,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures",
@@ -5747,13 +5935,14 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
+ "sp-timestamp",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "lazy_static",
  "lru",
@@ -5769,6 +5958,7 @@ dependencies = [
  "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
+ "sp-tasks",
  "sp-trie",
  "sp-version",
  "sp-wasm-interface",
@@ -5779,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "environmental",
  "parity-scale-codec 3.2.1",
@@ -5795,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "log",
  "parity-scale-codec 3.2.1",
@@ -5810,14 +6000,14 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "cfg-if",
  "libc",
  "log",
  "once_cell",
  "parity-scale-codec 3.2.1",
- "parity-wasm",
+ "parity-wasm 0.42.2",
  "rustix 0.35.13",
  "sc-allocator",
  "sc-executor-common",
@@ -5830,16 +6020,16 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "ahash",
- "array-bytes",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
  "futures",
  "futures-timer",
+ "hex",
  "log",
  "parity-scale-codec 3.2.1",
  "parking_lot 0.12.1",
@@ -5871,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "ansi_term",
  "futures",
@@ -5888,10 +6078,10 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "async-trait",
+ "hex",
  "parking_lot 0.12.1",
  "serde_json",
  "sp-application-crypto",
@@ -5903,9 +6093,8 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "async-trait",
  "asynchronous-codec",
  "bitflags",
@@ -5916,6 +6105,7 @@ dependencies = [
  "fork-tree",
  "futures",
  "futures-timer",
+ "hex",
  "ip_network",
  "libp2p",
  "linked-hash-map",
@@ -5926,6 +6116,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "prost",
+ "prost-build",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -5944,59 +6135,35 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "thiserror",
  "unsigned-varint",
- "zeroize",
-]
-
-[[package]]
-name = "sc-network-bitswap"
-version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
-dependencies = [
- "cid",
- "futures",
- "libp2p",
- "log",
- "prost",
- "prost-build",
- "sc-client-api",
- "sc-network-common",
- "sp-blockchain",
- "sp-runtime",
- "thiserror",
- "unsigned-varint",
  "void",
+ "zeroize",
 ]
 
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "futures",
- "futures-timer",
  "libp2p",
- "linked_hash_set",
  "parity-scale-codec 3.2.1",
  "prost-build",
  "sc-consensus",
  "sc-peerset",
- "serde",
  "smallvec",
- "sp-blockchain",
  "sp-consensus",
  "sp-finality-grandpa",
  "sp-runtime",
- "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "ahash",
  "futures",
@@ -6004,8 +6171,8 @@ dependencies = [
  "libp2p",
  "log",
  "lru",
+ "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -6014,10 +6181,10 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "futures",
+ "hex",
  "libp2p",
  "log",
  "parity-scale-codec 3.2.1",
@@ -6035,15 +6202,14 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "fork-tree",
  "futures",
+ "hex",
  "libp2p",
  "log",
  "lru",
- "mockall",
  "parity-scale-codec 3.2.1",
  "prost",
  "prost-build",
@@ -6051,7 +6217,6 @@ dependencies = [
  "sc-consensus",
  "sc-network-common",
  "sc-peerset",
- "sc-utils",
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
@@ -6063,45 +6228,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-network-transactions"
-version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
-dependencies = [
- "array-bytes",
- "futures",
- "hex",
- "libp2p",
- "log",
- "parity-scale-codec 3.2.1",
- "pin-project",
- "sc-network-common",
- "sc-peerset",
- "sp-consensus",
- "sp-runtime",
- "substrate-prometheus-endpoint",
-]
-
-[[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
+ "hex",
  "hyper",
  "hyper-rustls",
- "libp2p",
  "num_cpus",
  "once_cell",
  "parity-scale-codec 3.2.1",
  "parking_lot 0.12.1",
  "rand 0.7.3",
  "sc-client-api",
+ "sc-network",
  "sc-network-common",
- "sc-peerset",
  "sc-utils",
  "sp-api",
  "sp-core",
@@ -6114,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "libp2p",
@@ -6127,7 +6272,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6136,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "hash-db",
@@ -6166,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -6189,7 +6334,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -6200,28 +6345,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-rpc-spec-v2"
-version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
-dependencies = [
- "futures",
- "hex",
- "jsonrpsee",
- "parity-scale-codec 3.2.1",
- "sc-chain-spec",
- "sc-transaction-pool-api",
- "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "thiserror",
-]
-
-[[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "directories",
@@ -6245,15 +6371,12 @@ dependencies = [
  "sc-informant",
  "sc-keystore",
  "sc-network",
- "sc-network-bitswap",
  "sc-network-common",
  "sc-network-light",
  "sc-network-sync",
- "sc-network-transactions",
  "sc-offchain",
  "sc-rpc",
  "sc-rpc-server",
- "sc-rpc-spec-v2",
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
@@ -6280,7 +6403,6 @@ dependencies = [
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
- "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
@@ -6292,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "log",
  "parity-scale-codec 3.2.1",
@@ -6306,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "libc",
@@ -6325,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "chrono",
  "futures",
@@ -6343,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "ansi_term",
  "atty",
@@ -6374,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6385,9 +6507,8 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "async-trait",
  "futures",
  "futures-timer",
  "linked-hash-map",
@@ -6412,9 +6533,8 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "async-trait",
  "futures",
  "log",
  "serde",
@@ -6426,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6538,14 +6658,12 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
- "base16ct",
  "der",
  "generic-array 0.14.6",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -6635,18 +6753,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6779,11 +6897,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.9.0",
  "rand_core 0.6.4",
 ]
 
@@ -6872,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "hash-db",
  "log",
@@ -6882,7 +7000,6 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
- "sp-trie",
  "sp-version",
  "thiserror",
 ]
@@ -6890,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -6902,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "scale-info 2.3.0",
@@ -6915,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6930,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "parity-scale-codec 3.2.1",
@@ -6942,7 +7059,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "sp-api",
@@ -6954,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures",
  "log",
@@ -6989,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7008,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "parity-scale-codec 3.2.1",
@@ -7026,7 +7143,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "scale-info 2.3.0",
@@ -7040,18 +7157,18 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "array-bytes",
  "base58",
  "bitflags",
- "blake2",
+ "blake2-rfc",
  "byteorder",
  "dyn-clonable",
- "ed25519-zebra",
+ "ed25519-dalek",
  "futures",
  "hash-db",
  "hash256-std-hasher",
+ "hex",
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
@@ -7059,6 +7176,7 @@ dependencies = [
  "merlin",
  "num-traits",
  "parity-scale-codec 3.2.1",
+ "parity-util-mem",
  "parking_lot 0.12.1",
  "primitive-types",
  "rand 0.7.3",
@@ -7085,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "blake2",
  "byteorder",
@@ -7099,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7110,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -7119,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7129,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "environmental",
  "parity-scale-codec 3.2.1",
@@ -7140,7 +7258,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7158,7 +7276,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7172,7 +7290,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "bytes",
  "futures",
@@ -7198,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7209,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7226,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "thiserror",
  "zstd",
@@ -7235,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7245,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -7255,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7265,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7282,13 +7400,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-std",
- "sp-weights",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -7306,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7318,7 +7435,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "log",
  "parity-scale-codec 3.2.1",
@@ -7332,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "scale-info 2.3.0",
@@ -7346,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "scale-info 2.3.0",
@@ -7357,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "hash-db",
  "log",
@@ -7379,12 +7496,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec 3.2.1",
@@ -7395,9 +7512,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tasks"
+version = "4.0.0-dev"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
+dependencies = [
+ "log",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime-interface",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -7413,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "sp-std",
@@ -7425,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7434,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "async-trait",
  "log",
@@ -7450,22 +7580,15 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
- "ahash",
  "hash-db",
- "hashbrown",
- "lazy_static",
- "lru",
  "memory-db",
- "nohash-hasher",
  "parity-scale-codec 3.2.1",
- "parking_lot 0.12.1",
  "scale-info 2.3.0",
  "sp-core",
  "sp-std",
  "thiserror",
- "tracing",
  "trie-db",
  "trie-root",
 ]
@@ -7473,11 +7596,11 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec 3.2.1",
- "parity-wasm",
+ "parity-wasm 0.42.2",
  "scale-info 2.3.0",
  "serde",
  "sp-core-hashing-proc-macro",
@@ -7490,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "proc-macro2",
@@ -7501,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -7512,36 +7635,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-weights"
-version = "4.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec 3.2.1",
- "scale-info 2.3.0",
- "serde",
- "smallvec",
- "sp-arithmetic",
- "sp-core",
- "sp-debug-derive",
- "sp-std",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "ss58-registry"
@@ -7569,34 +7666,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "static_init"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
-dependencies = [
- "bitflags",
- "cfg_aliases",
- "libc",
- "parking_lot 0.11.2",
- "parking_lot_core 0.8.5",
- "static_init_macro",
- "winapi",
-]
-
-[[package]]
-name = "static_init_macro"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
-dependencies = [
- "cfg_aliases",
- "memchr",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "statrs"
@@ -7655,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "platforms",
 ]
@@ -7663,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -7684,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "futures-util",
  "hyper",
@@ -7697,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.9.33-1#8bc1bd4084a27353a250ecb8470eecac020b6ecd"
+source = "git+https://github.com/fragcolor-xyz/substrate.git?tag=fragnova-v0.0.6#90e07df9d09742cdbc7d2725e45123acd17442c3"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -7708,7 +7777,7 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
- "wasm-opt",
+ "wasm-gc-api",
 ]
 
 [[package]]
@@ -7719,9 +7788,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7797,10 +7866,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.4.0"
+name = "textwrap"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -7848,9 +7917,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
+version = "0.4.3+5.2.1-patched.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
 dependencies = [
  "cc",
  "fs_extra",
@@ -7859,9 +7928,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -7888,6 +7957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7904,9 +7982,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -7919,14 +7997,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8074,12 +8152,12 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004e1e8f92535694b4cb1444dc5a8073ecf0815e3357f729638b9f8fc4062908"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.12.3",
  "log",
  "rustc-hex",
  "smallvec",
@@ -8096,9 +8174,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.22.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -8110,30 +8188,30 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
+ "log",
  "rand 0.8.5",
  "smallvec",
  "thiserror",
  "tinyvec",
- "tracing",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.22.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
 dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
+ "log",
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tracing",
  "trust-dns-proto",
 ]
 
@@ -8163,9 +8241,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -8175,9 +8253,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8412,53 +8490,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "wasm-gc-api"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
+dependencies = [
+ "log",
+ "parity-wasm 0.32.0",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "wasm-instrument"
-version = "0.3.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1dafb3e60065305741e83db35c6c2584bb3725b692b5b66148a38d72ace6cd"
+checksum = "962e5b0401bbb6c887f54e69b8c496ea36f704df65db73e81fd5ff8dc3e63a9f"
 dependencies = [
- "parity-wasm",
-]
-
-[[package]]
-name = "wasm-opt"
-version = "0.110.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68e8037b4daf711393f4be2056246d12d975651b14d581520ad5d1f19219cec"
-dependencies = [
- "anyhow",
- "libc",
- "strum",
- "strum_macros",
- "tempfile",
- "thiserror",
- "wasm-opt-cxx-sys",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-cxx-sys"
-version = "0.110.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91adbad477e97bba3fbd21dd7bfb594e7ad5ceb9169ab1c93ab9cb0ada636b6f"
-dependencies = [
- "anyhow",
- "cxx",
- "cxx-build",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-sys"
-version = "0.110.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4fa5a322a4e6ac22fd141f498d56afbdbf9df5debeac32380d2dcaa3e06941"
-dependencies = [
- "anyhow",
- "cc",
- "cxx",
- "cxx-build",
- "regex",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -8478,63 +8526,58 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.13.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
+checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
 dependencies = [
- "parity-wasm",
+ "downcast-rs",
+ "libc",
+ "libm",
+ "memory_units",
+ "num-rational 0.2.4",
+ "num-traits",
+ "parity-wasm 0.42.2",
  "wasmi-validation",
- "wasmi_core",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.5.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
+checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
 dependencies = [
- "parity-wasm",
-]
-
-[[package]]
-name = "wasmi_core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
-dependencies = [
- "downcast-rs",
- "libm",
- "memory_units",
- "num-rational",
- "num-traits",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.89.1"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
+checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad5af6ba38311282f2a21670d96e78266e8c8e2f38cbcd52c254df6ccbc7731"
+checksum = "1f50eadf868ab6a04b7b511460233377d0bfbb92e417b2f6a98b98fef2e098f5"
 dependencies = [
  "anyhow",
+ "backtrace",
  "bincode",
  "cfg-if",
  "indexmap",
+ "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.28.4",
  "once_cell",
  "paste",
  "psm",
  "rayon",
+ "region",
  "serde",
  "target-lexicon",
  "wasmparser",
@@ -8543,23 +8586,14 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "wasmtime-asm-macros"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45de63ddfc8b9223d1adc8f7b2ee5f35d1f6d112833934ad7ea66e4f4339e597"
-dependencies = [
- "cfg-if",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd849399d17d2270141cfe47fa0d91ee52d5f8ea9b98cf7ddde0d53e5f79882"
+checksum = "d1df23c642e1376892f3b72f311596976979cbf8b85469680cdd3a8a063d12a2"
 dependencies = [
  "anyhow",
  "base64",
@@ -8567,19 +8601,19 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.35.13",
+ "rustix 0.33.7",
  "serde",
  "sha2 0.9.9",
  "toml",
- "windows-sys 0.36.1",
+ "winapi",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd91339b742ff20bfed4532a27b73c86b5bcbfedd6bea2dcdf2d64471e1b5c6"
+checksum = "f264ff6b4df247d15584f2f53d009fbc90032cfdc2605b52b961bffc71b6eccd"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8589,7 +8623,8 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "object",
+ "more-asserts",
+ "object 0.28.4",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -8598,16 +8633,17 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb881c61f4f627b5d45c54e629724974f8a8890d455bcbe634330cc27309644"
+checksum = "839d2820e4b830f4b9e7aa08d4c0acabf4a5036105d639f6dfa1c6891c73bdc6"
 dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
- "object",
+ "more-asserts",
+ "object 0.28.4",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -8617,9 +8653,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1985c628011fe26adf5e23a5301bdc79b245e0e338f14bb58b39e4e25e4d8681"
+checksum = "ef0a0bcbfa18b946d890078ba0e1bc76bcc53eccfb40806c0020ec29dcd1bd49"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -8628,36 +8664,38 @@ dependencies = [
  "cpp_demangle",
  "gimli",
  "log",
- "object",
+ "object 0.28.4",
+ "region",
  "rustc-demangle",
- "rustix 0.35.13",
+ "rustix 0.33.7",
  "serde",
  "target-lexicon",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-runtime",
- "windows-sys 0.36.1",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f671b588486f5ccec8c5a3dba6b4c07eac2e66ab8c60e6f4e53717c77f709731"
+checksum = "4f4779d976206c458edd643d1ac622b6c37e4a0800a8b1d25dfbf245ac2f2cac"
 dependencies = [
- "object",
- "once_cell",
- "rustix 0.35.13",
+ "lazy_static",
+ "object 0.28.4",
+ "rustix 0.33.7",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8f92ad4b61736339c29361da85769ebc200f184361959d1792832e592a1afd"
+checksum = "b7eb6ffa169eb5dcd18ac9473c817358cd57bc62c244622210566d473397954a"
 dependencies = [
  "anyhow",
+ "backtrace",
  "cc",
  "cfg-if",
  "indexmap",
@@ -8666,21 +8704,21 @@ dependencies = [
  "mach",
  "memfd",
  "memoffset 0.6.5",
- "paste",
+ "more-asserts",
  "rand 0.8.5",
- "rustix 0.35.13",
+ "region",
+ "rustix 0.33.7",
  "thiserror",
- "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "windows-sys 0.36.1",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "1.0.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
+checksum = "8d932b0ac5336f7308d869703dd225610a6a3aeaa8e968c52b43eed96cefb1c2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -8977,9 +9015,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9008,9 +9046,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.3+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,7 +18,7 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-build-script-utils]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '3.0.0'
 
 [dependencies.clamor-runtime]
@@ -28,7 +28,7 @@ version = '4.0.0-dev'
 [dependencies]
 jsonrpsee = { version = "0.15.1", features = ["server"] }
 log = { version = "0.4.14", default-features = false }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "3.0", features = ["derive"] }
 sp-clamor = { version = '0.1.0', path = '../primitives/clamor' }
 hex = { version = "0.4.3", default-features = false }
 protos = { version = "0.1.16", default-features = false }
@@ -36,161 +36,161 @@ serde_json = { version = '1.0.79', default-features = false, features = ['alloc'
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-benchmarking-cli]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-basic-authorship]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-cli]
 features = ['wasmtime']
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-client-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-consensus]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-consensus-aura]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-executor]
 features = ['wasmtime']
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-finality-grandpa]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-keystore]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-service]
 features = ['wasmtime']
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sc-telemetry]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-blockchain]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-keystore]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.12.0'
 
 [dependencies.sp-consensus]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sp-consensus-aura]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-finality-grandpa]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-runtime-interface]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-timestamp]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.substrate-frame-rpc-system]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
-[dependencies.pallet-contracts-primitives]
+[dependencies.pallet-contracts-rpc]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
-version = '6.0.0'
+tag = 'fragnova-v0.0.6'
+version = '4.0.0-dev'
 
 [dependencies.pallet-protos-rpc]
 path = '../pallets/protos/rpc'

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -48,12 +48,14 @@ where
 		+ Send
 		+ 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: pallet_protos_rpc::ProtosRuntimeApi<Block, AccountId>,
 	C::Api: pallet_fragments_rpc::FragmentsRuntimeApi<Block, AccountId>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {
+	use pallet_contracts_rpc::{Contracts, ContractsApiServer};
 	use pallet_fragments_rpc::{FragmentsRpcServer, FragmentsRpcServerImpl};
 	use pallet_protos_rpc::{ProtosRpcServer, ProtosRpcServerImpl};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
@@ -68,6 +70,7 @@ where
 	// more context: https://github.com/paritytech/substrate/pull/3480
 	// These RPCs should use an asynchronous caller instead.
 	io.merge(TransactionPayment::new(client.clone()).into_rpc())?;
+	io.merge(Contracts::new(client.clone()).into_rpc())?;
 
 	io.merge(Dev::new(client.clone(), deny_unsafe).into_rpc())?;
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -9,7 +9,7 @@
 // ```
 
 use clamor_runtime::{self, opaque::Block, RuntimeApi};
-use sc_client_api::BlockBackend;
+use sc_client_api::{BlockBackend, ExecutorProvider};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 pub use sc_executor::NativeElseWasmExecutor;
 use sc_finality_grandpa::SharedVoterState;
@@ -127,7 +127,7 @@ pub fn new_partial(
 	let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
 
 	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
+		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, _>(ImportQueueParams {
 			block_import: grandpa_block_import.clone(),
 			justification_import: Some(Box::new(grandpa_block_import.clone())),
 			client: client.clone(),
@@ -140,13 +140,15 @@ pub fn new_partial(
 						slot_duration,
 					);
 
-				Ok((slot, timestamp))
+				Ok((timestamp, slot))
 			},
 			spawner: &task_manager.spawn_essential_handle(),
+			can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(
+				client.executor().clone(),
+			),
 			registry: config.prometheus_registry(),
 			check_for_equivocation: Default::default(),
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
-			compatibility_mode: Default::default(),
 		})?;
 
 	Ok(sc_service::PartialComponents {
@@ -211,7 +213,7 @@ pub fn new_full(
 		Vec::default(),
 	));
 
-	let (network, system_rpc_tx, tx_handler_controller, network_starter) =
+	let (network, system_rpc_tx, network_starter) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &config,
 			client: client.clone(),
@@ -261,7 +263,6 @@ pub fn new_full(
 		rpc_builder: rpc_extensions_builder,
 		backend,
 		system_rpc_tx,
-		tx_handler_controller,
 		config,
 		telemetry: telemetry.as_mut(),
 	})?;
@@ -275,9 +276,12 @@ pub fn new_full(
 			telemetry.as_ref().map(|x| x.handle()),
 		);
 
+		let can_author_with =
+			sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+
 		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
 
-		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _>(
+		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _, _>(
 			StartAuraParams {
 				slot_duration,
 				client: client.clone(),
@@ -293,17 +297,17 @@ pub fn new_full(
 							slot_duration,
 						);
 
-					Ok((slot, timestamp))
+					Ok((timestamp, slot))
 				},
 				force_authoring,
 				backoff_authoring_blocks,
 				keystore: keystore_container.sync_keystore(),
+				can_author_with,
 				sync_oracle: network.clone(),
 				justification_sync_link: network.clone(),
 				block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
 				max_block_proposal_slot_portion: None,
 				telemetry: telemetry.as_ref().map(|x| x.handle()),
-				compatibility_mode: Default::default(),
 			},
 		)?;
 

--- a/pallets/accounts/Cargo.toml
+++ b/pallets/accounts/Cargo.toml
@@ -13,31 +13,31 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-keystore]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.12.0'
 optional = true
 
@@ -50,20 +50,20 @@ version = '3.0.0'
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 optional = true
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -74,31 +74,31 @@ version = '2.0'
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-assets]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-proxy]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies]
@@ -107,7 +107,7 @@ sp-clamor = { version = '0.1.0', path = '../../primitives/clamor', default-featu
 hex = { version = "0.4.3", default-features = false }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 serde_json = { version = '1.0.79', default-features = false, features = ['alloc'] }
-ethabi = { version = "18.0.0", default-features = false }
+ethabi = { version = "17.0.0", default-features = false }
 libsecp256k1 = {version = "0.7.0", default-features = false} # https://crates.io/crates/libsecp256k1 (libsecp256k1 is owned by Parity Tech by the way)
 
 [dev-dependencies]

--- a/pallets/accounts/src/benchmarking.rs
+++ b/pallets/accounts/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn get_ethereum_public_key(secret_key_struct: &libsecp256k1::SecretKey) -> H160 
 	H160::from_slice(&ethereum_account_id)
 }
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/accounts/src/dummy_data.rs
+++ b/pallets/accounts/src/dummy_data.rs
@@ -2,12 +2,14 @@ use std::str::FromStr;
 use crate::*;
 
 use codec::Encode;
-use ethabi::ethereum_types::{Address, H160, U256};
+use ethabi::ethereum_types::{Address};
 
 use sp_core::{
 	ecdsa,
 	keccak_256,
 	Pair,
+	H160, // size of an Ethereum Account Address
+	U256,
 };
 
 #[cfg(test)]

--- a/pallets/accounts/src/lib.rs
+++ b/pallets/accounts/src/lib.rs
@@ -219,7 +219,7 @@ pub mod pallet {
 	+ pallet_assets::Config
 	{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Weight functions needed for pallet_accounts.
 		type WeightInfo: WeightInfo;

--- a/pallets/accounts/src/mock.rs
+++ b/pallets/accounts/src/mock.rs
@@ -65,8 +65,8 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
+	type Origin = Origin;
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -74,7 +74,7 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::ed25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -87,7 +87,7 @@ impl frame_system::Config for Test {
 	type MaxConsumers = ConstU32<2>;
 }
 
-pub type Extrinsic = TestXt<RuntimeCall, ()>;
+pub type Extrinsic = TestXt<Call, ()>;
 type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 impl frame_system::offchain::SigningTypes for Test {
@@ -97,22 +97,22 @@ impl frame_system::offchain::SigningTypes for Test {
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
-	type OverarchingCall = RuntimeCall;
+	type OverarchingCall = Call;
 	type Extrinsic = Extrinsic;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
 	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: RuntimeCall,
+		call: Call,
 		_public: <Signature as Verify>::Signer,
 		_account: AccountId,
 		nonce: u64,
-	) -> Option<(RuntimeCall, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
 		Some((call, (nonce, ())))
 	}
 }
@@ -122,7 +122,7 @@ impl pallet_randomness_collective_flip::Config for Test {}
 impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	/// The minimum amount required to keep an account open.
 	type ExistentialDeposit = ConstU128<500>;
 	type AccountStore = System;
@@ -141,7 +141,7 @@ parameter_types! {
 	pub const MetadataDepositPerByte: Balance = 1 * DOLLARS;
 }
 impl pallet_assets::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type Balance = Balance;
 	type AssetId = u64;
 	type Currency = Balances;
@@ -155,7 +155,6 @@ impl pallet_assets::Config for Test {
 	type Freezer = ();
 	type WeightInfo = ();
 	type Extra = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 }
 
 impl pallet_accounts::EthFragContract for Test {
@@ -169,7 +168,7 @@ parameter_types! {
 }
 
 impl pallet_accounts::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type EthChainId = ConstU64<5>; // goerli
 	type EthConfirmations = ConstU64<1>;
@@ -183,8 +182,8 @@ impl pallet_accounts::Config for Test {
 }
 
 impl pallet_proxy::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
+	type Event = Event;
+	type Call = Call;
 	type Currency = Balances;
 	type ProxyType = ();
 	type ProxyDepositBase = ConstU128<1>;

--- a/pallets/accounts/src/tests.rs
+++ b/pallets/accounts/src/tests.rs
@@ -29,7 +29,7 @@ mod link_tests {
 	use super::*;
 
 	pub fn link_(link: &Link) -> DispatchResult {
-		Accounts::link(RuntimeOrigin::signed(link.clamor_account_id), link.link_signature.clone())
+		Accounts::link(Origin::signed(link.clamor_account_id), link.link_signature.clone())
 	}
 
 	#[test]
@@ -56,7 +56,7 @@ mod link_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::Linked {
+				mock::Event::from(pallet_accounts::Event::Linked {
 					sender: link.clamor_account_id,
 					eth_key: link.get_ethereum_public_address_of_signer()
 				})
@@ -142,7 +142,7 @@ mod unlink_tests {
 			assert_ok!(link_(&link));
 
 			assert_ok!(Accounts::unlink(
-				RuntimeOrigin::signed(link.clamor_account_id),
+				Origin::signed(link.clamor_account_id),
 				link.get_ethereum_public_address_of_signer()
 			));
 
@@ -160,7 +160,7 @@ mod unlink_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::Unlinked {
+				mock::Event::from(pallet_accounts::Event::Unlinked {
 					sender: link.clamor_account_id,
 					eth_key: link.get_ethereum_public_address_of_signer(),
 				})
@@ -176,7 +176,7 @@ mod unlink_tests {
 
 			assert_noop!(
 				Accounts::unlink(
-					RuntimeOrigin::signed(link.clamor_account_id),
+					Origin::signed(link.clamor_account_id),
 					link.get_ethereum_public_address_of_signer()
 				),
 				Error::<Test>::AccountNotLinked
@@ -199,7 +199,7 @@ mod unlink_tests {
 
 			assert_noop!(
 				Accounts::unlink(
-					RuntimeOrigin::signed(link.clamor_account_id),
+					Origin::signed(link.clamor_account_id),
 					link_second.get_ethereum_public_address_of_signer()
 				),
 				Error::<Test>::DifferentAccountLinked
@@ -342,7 +342,7 @@ mod sync_partner_contracts_tests {
 			let tx = <Extrinsic as codec::Decode>::decode(&mut &*tx).unwrap();
 			assert_eq!(tx.signature, None); // Because it's an **unsigned transaction** with a signed payload
 
-			if let RuntimeCall::Accounts(crate::Call::internal_lock_update { data, signature }) =
+			if let Call::Accounts(crate::Call::internal_lock_update { data, signature }) =
 				tx.call
 			{
 				assert_eq!(data, expected_data);
@@ -366,7 +366,7 @@ mod internal_lock_update_tests {
 
 	pub fn lock_(lock: &Lock) -> DispatchResult {
 		Accounts::internal_lock_update(
-			RuntimeOrigin::none(),
+			Origin::none(),
 			lock.data.clone(),
 			sp_core::ed25519::Signature([69u8; 64]), // this can be anything and it will still work
 		)
@@ -374,7 +374,7 @@ mod internal_lock_update_tests {
 
 	pub fn unlock_(unlock: &Unlock) -> DispatchResult {
 		Accounts::internal_lock_update(
-			RuntimeOrigin::none(),
+			Origin::none(),
 			unlock.data.clone(),
 			sp_core::ed25519::Signature([69u8; 64]), // this can be anything
 		)
@@ -448,7 +448,7 @@ mod internal_lock_update_tests {
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::Locked {
+				mock::Event::from(pallet_accounts::Event::Locked {
 					eth_key: lock.data.sender.clone(),
 					balance: SaturatedConversion::saturated_into::<
 						<Test as pallet_assets::Config>::Balance,
@@ -510,7 +510,7 @@ mod internal_lock_update_tests {
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::Locked {
+				mock::Event::from(pallet_accounts::Event::Locked {
 					eth_key: lock.data.sender,
 					balance: SaturatedConversion::saturated_into::<
 						<Test as pallet_assets::Config>::Balance,
@@ -522,7 +522,7 @@ mod internal_lock_update_tests {
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::NOVAReserved {
+				mock::Event::from(pallet_accounts::Event::NOVAReserved {
 					eth_key: lock.data.sender.clone(),
 					balance: SaturatedConversion::saturated_into::<
 						<Test as pallet_balances::Config>::Balance,
@@ -537,7 +537,7 @@ mod internal_lock_update_tests {
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::TicketsReserved {
+				mock::Event::from(pallet_accounts::Event::TicketsReserved {
 					eth_key: lock.data.sender.clone(),
 					balance: SaturatedConversion::saturated_into::<
 						<Test as pallet_assets::Config>::Balance,
@@ -806,7 +806,7 @@ mod internal_lock_update_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_accounts::Event::Unlocked {
+				mock::Event::from(pallet_accounts::Event::Unlocked {
 					eth_key: unlock.data.sender,
 					balance: SaturatedConversion::saturated_into::<
 						<Test as pallet_assets::Config>::Balance,
@@ -842,7 +842,7 @@ mod withdraw_tests {
 	use super::*;
 
 	fn withdraw_(lock: &Lock) -> DispatchResult {
-		Accounts::withdraw(RuntimeOrigin::signed(lock.link.clamor_account_id))
+		Accounts::withdraw(Origin::signed(lock.link.clamor_account_id))
 	}
 
 	pub fn get_initial_amounts(lock: &Lock) -> (u128, u128) {

--- a/pallets/accounts/src/weights.rs
+++ b/pallets/accounts/src/weights.rs
@@ -61,32 +61,32 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Accounts FragKeys (r:1 w:1)
 	fn add_key() -> Weight {
-		Weight::from_ref_time(6_401_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(6_401_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts FragKeys (r:1 w:1)
 	fn del_key() -> Weight {
-		Weight::from_ref_time(6_890_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(6_890_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
 	// Storage: Accounts EthReservedTickets (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:1 w:0)
 	fn link() -> Weight {
-		Weight::from_ref_time(58_668_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
+		(58_668_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
 	// Storage: Accounts PendingUnlinks (r:1 w:1)
 	fn unlink() -> Weight {
-		Weight::from_ref_time(23_631_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+		(23_631_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Accounts EVMLinkVotingClosed (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:0)
@@ -94,30 +94,30 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Accounts EthReservedTickets (r:0 w:1)
 	// Storage: Accounts EthLockedFrag (r:0 w:1)
 	fn internal_lock_update() -> Weight {
-		Weight::from_ref_time(67_671_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(2 as u64))
-			.saturating_add(T::DbWeight::get().writes(4 as u64))
+		(67_671_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: Accounts ExternalID2Account (r:0 w:1)
 	fn sponsor_account() -> Weight {
-		Weight::from_ref_time(37_290_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
+		(37_290_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:1)
 	fn add_sponsor() -> Weight {
-		Weight::from_ref_time(6_491_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(6_491_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:1)
 	fn remove_sponsor() -> Weight {
-		Weight::from_ref_time(7_589_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(7_589_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }
 
@@ -125,32 +125,32 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: Accounts FragKeys (r:1 w:1)
 	fn add_key() -> Weight {
-		Weight::from_ref_time(6_401_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(6_401_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts FragKeys (r:1 w:1)
 	fn del_key() -> Weight {
-		Weight::from_ref_time(6_890_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(6_890_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
 	// Storage: Accounts EthReservedTickets (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:1 w:0)
 	fn link() -> Weight {
-		Weight::from_ref_time(58_668_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
+		(58_668_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
 	// Storage: Accounts PendingUnlinks (r:1 w:1)
 	fn unlink() -> Weight {
-		Weight::from_ref_time(23_631_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(3 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+		(23_631_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Accounts EVMLinkVotingClosed (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:0)
@@ -158,29 +158,29 @@ impl WeightInfo for () {
 	// Storage: Accounts EthReservedTickets (r:0 w:1)
 	// Storage: Accounts EthLockedFrag (r:0 w:1)
 	fn internal_lock_update() -> Weight {
-		Weight::from_ref_time(67_671_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(2 as u64))
-			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+		(67_671_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: Accounts ExternalID2Account (r:0 w:1)
 	fn sponsor_account() -> Weight {
-		Weight::from_ref_time(37_290_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(3 as u64))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
+		(37_290_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:1)
 	fn add_sponsor() -> Weight {
-		Weight::from_ref_time(6_491_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(6_491_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Accounts ExternalAuthorities (r:1 w:1)
 	fn remove_sponsor() -> Weight {
-		Weight::from_ref_time(7_589_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(7_589_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }

--- a/pallets/detach/Cargo.toml
+++ b/pallets/detach/Cargo.toml
@@ -16,31 +16,31 @@ version = '1.0.119'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-keystore]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.12.0'
 optional = true
 
@@ -53,20 +53,20 @@ version = '3.0.0'
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 optional = true
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -77,7 +77,7 @@ version = '2.0'
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies]

--- a/pallets/detach/src/lib.rs
+++ b/pallets/detach/src/lib.rs
@@ -189,7 +189,7 @@ pub mod pallet {
 		+ frame_system::Config
 	{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Weight functions needed for pallet_detach.
 		type WeightInfo: WeightInfo;
 		/// The identifier type for an offchain worker.

--- a/pallets/detach/src/mock.rs
+++ b/pallets/detach/src/mock.rs
@@ -63,8 +63,8 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
+	type Origin = Origin;
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -72,7 +72,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId; // type AccountId = sp_core::ed25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -90,24 +90,24 @@ impl frame_system::offchain::SigningTypes for Test {
 	type Signature = Signature;
 }
 
-pub type Extrinsic = TestXt<RuntimeCall, ()>;
+pub type Extrinsic = TestXt<Call, ()>;
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
 	where
-		RuntimeCall: From<LocalCall>,
+		Call: From<LocalCall>,
 {
-	type OverarchingCall = RuntimeCall;
+	type OverarchingCall = Call;
 	type Extrinsic = Extrinsic;
 }
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
 	where
-		RuntimeCall: From<LocalCall>,
+		Call: From<LocalCall>,
 {
 	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: RuntimeCall,
+		call: Call,
 		_public: <Signature as Verify>::Signer,
 		_account: AccountId,
 		nonce: u64,
-	) -> Option<(RuntimeCall, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
 		Some((call, (nonce, ())))
 	}
 }
@@ -115,7 +115,7 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for T
 impl pallet_randomness_collective_flip::Config for Test {}
 
 impl pallet_detach::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type AuthorityId = pallet_detach::crypto::DetachAuthId;
 }

--- a/pallets/detach/src/tests.rs
+++ b/pallets/detach/src/tests.rs
@@ -85,8 +85,8 @@ mod process_detach_requests_tests {
 
 			let computed_ecdsa_key = deterministically_compute_ecdsa_key(KEY_TYPE, ed25519_public_key);
 
-			assert_ok!(DetachPallet::add_key(RuntimeOrigin::root(), ed25519_public_key));
-			assert_ok!(DetachPallet::add_eth_auth(RuntimeOrigin::root(), computed_ecdsa_key));
+			assert_ok!(DetachPallet::add_key(Origin::root(), ed25519_public_key));
+			assert_ok!(DetachPallet::add_eth_auth(Origin::root(), computed_ecdsa_key));
 
 			DetachPallet::process_detach_requests();
 
@@ -104,7 +104,7 @@ mod process_detach_requests_tests {
 			let tx = <Extrinsic as codec::Decode>::decode(&mut &*tx).unwrap();
 			assert_eq!(tx.signature, None); // Because `DetachPallet::process_detach_requests()` sends an unsigned transaction with a signed payload
 
-			let RuntimeCall::DetachPallet(crate::Call::internal_finalize_detach { data, signature }) = tx.call else {
+			let Call::DetachPallet(crate::Call::internal_finalize_detach { data, signature }) = tx.call else {
 				panic!("The unsigned transaction that was sent is incorrect!");
 			};
 
@@ -149,8 +149,8 @@ mod process_detach_requests_tests {
 
 			let computed_ecdsa_key = deterministically_compute_ecdsa_key(KEY_TYPE, ed25519_public_key);
 
-			assert_ok!(DetachPallet::add_key(RuntimeOrigin::root(), ed25519_public_key));
-			// assert_ok!(DetachPallet::add_eth_auth(RuntimeOrigin::root(), computed_ecdsa_key)); // no ECDSA key in the keystore under `KEY_TYPE` is an Ethereum Authority
+			assert_ok!(DetachPallet::add_key(Origin::root(), ed25519_public_key));
+			// assert_ok!(DetachPallet::add_eth_auth(Origin::root(), computed_ecdsa_key)); // no ECDSA key in the keystore under `KEY_TYPE` is an Ethereum Authority
 
 			DetachPallet::process_detach_requests();
 
@@ -195,7 +195,7 @@ mod validate_unsigned_tests {
 
 			let crate::Call::internal_finalize_detach {ref data, signature: _} = validate_unsigned.call else { panic!() };
 
-			assert_ok!(DetachPallet::add_key(RuntimeOrigin::root(), TryInto::<ed25519::Public>::try_into(data.public.clone()).unwrap()));
+			assert_ok!(DetachPallet::add_key(Origin::root(), TryInto::<ed25519::Public>::try_into(data.public.clone()).unwrap()));
 			assert!(validate_unsigned_(&validate_unsigned).is_ok());
 		})
 	}
@@ -243,7 +243,7 @@ mod validate_unsigned_tests {
 				..dd.validate_unsigned
 			};
 
-			assert_ok!(DetachPallet::add_key(RuntimeOrigin::root(), TryInto::<ed25519::Public>::try_into(data.public.clone()).unwrap()));
+			assert_ok!(DetachPallet::add_key(Origin::root(), TryInto::<ed25519::Public>::try_into(data.public.clone()).unwrap()));
 			assert_eq!(
 				<DetachPallet as sp_runtime::traits::ValidateUnsigned>::validate_unsigned(
 					validate_unsigned.source,

--- a/pallets/detach/src/weights.rs
+++ b/pallets/detach/src/weights.rs
@@ -53,15 +53,15 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Detach EthereumAuthorities (r:1 w:1)
 	fn add_eth_auth() -> Weight {
-		Weight::from_ref_time(3_000_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(3_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Detach EthereumAuthorities (r:1 w:1)
 	fn del_eth_auth() -> Weight {
-		Weight::from_ref_time(3_000_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(3_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }
 
@@ -69,14 +69,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: Detach EthereumAuthorities (r:1 w:1)
 	fn add_eth_auth() -> Weight {
-		Weight::from_ref_time(3_000_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(3_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Detach EthereumAuthorities (r:1 w:1)
 	fn del_eth_auth() -> Weight {
-		Weight::from_ref_time(3_000_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(3_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }

--- a/pallets/fragments/Cargo.toml
+++ b/pallets/fragments/Cargo.toml
@@ -19,20 +19,20 @@ version = '3.0.0'
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 optional = true
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -43,25 +43,25 @@ version = '2.0'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.pallet-protos]
@@ -75,13 +75,13 @@ path = '../detach'
 [dependencies.pallet-assets]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-accounts]
@@ -91,19 +91,19 @@ path = '../accounts'
 [dependencies.pallet-proxy]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies]
@@ -118,7 +118,7 @@ bitflags = "1.3.2"
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dev-dependencies]

--- a/pallets/fragments/rpc/Cargo.toml
+++ b/pallets/fragments/rpc/Cargo.toml
@@ -20,22 +20,22 @@ protos = { version = "0.1.15", default-features = false }
 # Substrate Dependencies
 [dependencies.sp-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-rpc]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-blockchain]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-fragments-rpc-runtime-api]

--- a/pallets/fragments/rpc/runtime-api/Cargo.toml
+++ b/pallets/fragments/rpc/runtime-api/Cargo.toml
@@ -17,20 +17,20 @@ sp-clamor = { version = '0.1.0', path = '../../../../primitives/clamor', default
 # Substrate Dependencies
 [dependencies.sp-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 default-features = false
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-fragments]

--- a/pallets/fragments/src/benchmarking.rs
+++ b/pallets/fragments/src/benchmarking.rs
@@ -24,10 +24,10 @@ const MAX_DATA_LENGTH: u32 = 1_000_000; // 1 MegaByte
 const MAX_METADATA_NAME_LENGTH: u32 = 100;
 const MAX_QUANTITY_TO_MINT: u32 = 100;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
-fn assert_has_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_has_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
 }
 

--- a/pallets/fragments/src/lib.rs
+++ b/pallets/fragments/src/lib.rs
@@ -317,7 +317,7 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_protos::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Weight functions needed for pallet_fragments.
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/fragments/src/mock.rs
+++ b/pallets/fragments/src/mock.rs
@@ -66,8 +66,8 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
+	type Origin = Origin;
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -75,7 +75,7 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::ed25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -88,7 +88,7 @@ impl frame_system::Config for Test {
 	type MaxConsumers = ConstU32<2>;
 }
 
-pub type Extrinsic = TestXt<RuntimeCall, ()>;
+pub type Extrinsic = TestXt<Call, ()>;
 type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 impl frame_system::offchain::SigningTypes for Test {
@@ -98,22 +98,22 @@ impl frame_system::offchain::SigningTypes for Test {
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
-	type OverarchingCall = RuntimeCall;
+	type OverarchingCall = Call;
 	type Extrinsic = Extrinsic;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
 	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: RuntimeCall,
+		call: Call,
 		_public: <Signature as Verify>::Signer,
 		_account: AccountId,
 		nonce: u64,
-	) -> Option<(RuntimeCall, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
 		Some((call, (nonce, ())))
 	}
 }
@@ -123,7 +123,7 @@ impl pallet_randomness_collective_flip::Config for Test {}
 impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	/// The minimum amount required to keep an account open.
 	type ExistentialDeposit = ConstU128<500>;
 	type AccountStore = System;
@@ -143,7 +143,7 @@ parameter_types! {
 }
 
 impl pallet_assets::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type Balance = Balance;
 	type AssetId = u64;
 	type Currency = Balances;
@@ -157,11 +157,10 @@ impl pallet_assets::Config for Test {
 	type Freezer = ();
 	type WeightInfo = ();
 	type Extra = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 }
 
 parameter_types! {
-	pub const DeletionWeightLimit: Weight = Weight::from_ref_time(500_000_000_000);
+	pub const DeletionWeightLimit: Weight = 500_000_000_000;
 	pub MySchedule: pallet_contracts::Schedule<Test> = {
 		let mut schedule = <pallet_contracts::Schedule<Test>>::default();
 		// We want stack height to be always enabled for tests so that this
@@ -171,14 +170,16 @@ parameter_types! {
 	};
 	pub static DepositPerByte: u64 = 1;
 	pub const DepositPerItem: u64 = 2;
+	pub BlockWeights: frame_system::limits::BlockWeights =
+		frame_system::limits::BlockWeights::simple_max(2 * WEIGHT_PER_SECOND);
 }
 
 impl pallet_contracts::Config for Test {
 	type Time = Timestamp;
 	type Randomness = CollectiveFlip;
 	type Currency = Balances;
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
+	type Event = Event;
+	type Call = Call;
 	type CallFilter = frame_support::traits::Nothing;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
@@ -190,7 +191,9 @@ impl pallet_contracts::Config for Test {
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = MySchedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
+	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<BlockWeights>;
 	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
+	type RelaxedMaxCodeLen = ConstU32<{ 256 * 1024 }>;
 	type MaxStorageKeyLen = ConstU32<128>;
 }
 
@@ -199,7 +202,7 @@ parameter_types! {
 }
 
 impl pallet_protos::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type StorageBytesMultiplier = StorageBytesMultiplier;
 	type CurationExpiration = ConstU64<5>;
@@ -207,7 +210,7 @@ impl pallet_protos::Config for Test {
 }
 
 impl pallet_accounts::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type EthChainId = ConstU64<5>; // goerli
 	type EthFragContract = ();
@@ -221,8 +224,8 @@ impl pallet_accounts::Config for Test {
 }
 
 impl pallet_proxy::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
+	type Event = Event;
+	type Call = Call;
 	type Currency = Balances;
 	type ProxyType = ();
 	type ProxyDepositBase = ConstU128<1>;
@@ -236,12 +239,12 @@ impl pallet_proxy::Config for Test {
 }
 
 impl pallet_fragments::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 }
 
 impl pallet_detach::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type AuthorityId = pallet_detach::crypto::DetachAuthId;
 }

--- a/pallets/fragments/src/tests.rs
+++ b/pallets/fragments/src/tests.rs
@@ -23,7 +23,7 @@ mod copied_from_pallet_protos {
 		proto: &ProtoFragment,
 	) -> DispatchResult {
 		Protos::upload(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			proto.references.clone(),
 			proto.category.clone(),
 			proto.tags.clone(),
@@ -46,7 +46,7 @@ mod create_tests {
 		definition: &Definition,
 	) -> DispatchResult {
 		FragmentsPallet::create(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			definition.proto_fragment.get_proto_hash(),
 			definition.metadata.clone(),
 			definition.permissions,
@@ -180,7 +180,7 @@ mod create_tests {
 			assert_noop!(create(dd.account_id, &definition), Error::<Test>::CurrencyNotFound);
 
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true, // Whether this asset needs users to have an existential deposit to hold this asset
@@ -208,7 +208,7 @@ mod publish_tests {
 		publish: &Publish,
 	) -> DispatchResult {
 		FragmentsPallet::publish(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			publish.definition.get_definition_id(),
 			publish.price,
 			publish.quantity,
@@ -356,7 +356,7 @@ mod unpublish_tests {
 		signer: <Test as frame_system::Config>::AccountId,
 		definition: &Definition,
 	) -> DispatchResult {
-		FragmentsPallet::unpublish(RuntimeOrigin::signed(signer), definition.get_definition_id())
+		FragmentsPallet::unpublish(Origin::signed(signer), definition.get_definition_id())
 	}
 
 	#[test]
@@ -446,7 +446,7 @@ mod mint_tests {
 
 	pub fn mint_(signer: <Test as frame_system::Config>::AccountId, mint: &Mint) -> DispatchResult {
 		FragmentsPallet::mint(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			mint.definition.get_definition_id(),
 			mint.buy_options.clone(),
 			mint.amount.clone(),
@@ -734,7 +734,7 @@ mod buy_tests {
 
 	fn buy_(signer: <Test as frame_system::Config>::AccountId, buy: &Buy) -> DispatchResult {
 		FragmentsPallet::buy(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			buy.publish.definition.get_definition_id(),
 			buy.buy_options.clone(),
 		)
@@ -982,7 +982,7 @@ mod buy_tests {
 
 			let minimum_balance = 1;
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -999,7 +999,7 @@ mod buy_tests {
 			};
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				buy.publish.price.saturating_mul(quantity as u128) + minimum_balance - 1,
@@ -1007,7 +1007,7 @@ mod buy_tests {
 			assert_noop!(buy_(dd.account_id_second, &buy), Error::<Test>::InsufficientBalance);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_third,
 				buy.publish.price.saturating_mul(quantity as u128) + minimum_balance,
@@ -1037,7 +1037,7 @@ mod buy_tests {
 
 			let minimum_balance = buy.publish.price.saturating_mul(quantity as u128); // vault ID wil have minimum balance after `buy()` transaction
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -1048,7 +1048,7 @@ mod buy_tests {
 			publish_definition(dd.account_id, &buy);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				buy.publish.price.saturating_mul(quantity as u128) + minimum_balance,
@@ -1078,7 +1078,7 @@ mod buy_tests {
 
 			let minimum_balance = buy.publish.price.saturating_mul(quantity as u128) + 1; // vault ID wil not have minimum balance after `buy()` transaction
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -1089,7 +1089,7 @@ mod buy_tests {
 			publish_definition(dd.account_id, &buy);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				buy.publish.price.saturating_mul(quantity as u128) + minimum_balance,
@@ -1291,7 +1291,7 @@ mod give_tests {
 		give: &Give,
 	) -> DispatchResult {
 		FragmentsPallet::give(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			give.mint.definition.get_definition_id(),
 			give.edition_id,
 			give.copy_id,
@@ -1705,7 +1705,7 @@ mod create_account_tests {
 		create_account: &CreateAccount,
 	) -> DispatchResult {
 		FragmentsPallet::create_account(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			create_account.mint.definition.get_definition_id(),
 			create_account.edition_id,
 			create_account.copy_id,
@@ -1755,7 +1755,7 @@ mod resell_tests {
 		resell: &Resell
 	) -> DispatchResult {
 		FragmentsPallet::resell(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			resell.mint.definition.get_definition_id(),
 			resell.edition_id,
 			resell.copy_id,
@@ -2067,7 +2067,7 @@ mod end_resale_tests {
 		end_resale: &EndResale
 	) -> DispatchResult {
 		FragmentsPallet::end_resale(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			end_resale.resell.mint.definition.get_definition_id(),
 			end_resale.resell.edition_id,
 			end_resale.resell.copy_id,
@@ -2146,7 +2146,7 @@ mod secondary_buy_tests {
 		secondary_buy: &SecondaryBuy
 	) -> DispatchResult {
 		FragmentsPallet::secondary_buy(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			secondary_buy.resell.mint.definition.get_definition_id(),
 			secondary_buy.resell.edition_id,
 			secondary_buy.resell.copy_id,
@@ -2401,7 +2401,7 @@ mod secondary_buy_tests {
 
 			let minimum_balance = 1;
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -2416,7 +2416,7 @@ mod secondary_buy_tests {
 			};
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				price + minimum_balance - 1,
@@ -2424,7 +2424,7 @@ mod secondary_buy_tests {
 			assert_noop!(secondary_buy_(dd.account_id_second, &secondary_buy), Error::<Test>::InsufficientBalance);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_third,
 				price + minimum_balance,
@@ -2452,7 +2452,7 @@ mod secondary_buy_tests {
 
 			let minimum_balance = price;
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -2463,7 +2463,7 @@ mod secondary_buy_tests {
 			resell_instance(dd.account_id, &secondary_buy);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				price + minimum_balance,
@@ -2491,7 +2491,7 @@ mod secondary_buy_tests {
 
 			let minimum_balance = price + 1;
 			assert_ok!(Assets::force_create(
-				RuntimeOrigin::root(),
+				Origin::root(),
 				asset_id, // The identifier of the new asset. This must not be currently in use to identify an existing asset.
 				dd.account_id, // The owner of this class of assets. The owner has full superuser permissions over this asset, but may later change and configure the permissions using transfer_ownership and set_team.
 				true,          // Whether this asset needs users to have an existential deposit to hold this asset
@@ -2502,7 +2502,7 @@ mod secondary_buy_tests {
 			resell_instance(dd.account_id, &secondary_buy);
 
 			assert_ok!(Assets::mint(
-				RuntimeOrigin::signed(dd.account_id),
+				Origin::signed(dd.account_id),
 				asset_id,
 				dd.account_id_second,
 				price + minimum_balance,
@@ -2526,7 +2526,7 @@ mod detach_tests {
 		detach: &Detach,
 	) -> DispatchResult {
 		FragmentsPallet::detach(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			detach.mint.definition.get_definition_id(),
 			detach.edition_id,
 			detach.copy_id,

--- a/pallets/fragments/src/weights.rs
+++ b/pallets/fragments/src/weights.rs
@@ -68,11 +68,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments Proto2Fragments (r:1 w:1)
 	/// The range of component `n` is `[1, 100]`.
 	fn create(n: u32, ) -> Weight {
-		Weight::from_ref_time(53_058_000 as u64)
+		(53_058_000 as Weight)
 			// Standard Error: 9_000
-			.saturating_add(Weight::from_ref_time(10_000 as u64).saturating_mul(n as u64))
-			.saturating_add(T::DbWeight::get().reads(6 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add((10_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:0)
 	// Storage: Protos Protos (r:1 w:0)
@@ -80,18 +80,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments EditionsCount (r:1 w:0)
 	fn publish() -> Weight {
-		Weight::from_ref_time(34_050_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(34_050_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:0)
 	// Storage: Protos Protos (r:1 w:0)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Fragments Publishing (r:1 w:1)
 	fn unpublish() -> Weight {
-		Weight::from_ref_time(32_337_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(32_337_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:1)
 	// Storage: Protos Protos (r:1 w:0)
@@ -104,12 +104,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `q` is `[1, 100]`.
 	fn mint_definition_that_has_non_unique_capability(q: u32, ) -> Weight {
-		Weight::from_ref_time(36_569_000 as u64)
+		(36_569_000 as Weight)
 			// Standard Error: 133_000
-			.saturating_add(Weight::from_ref_time(8_255_000 as u64).saturating_mul(q as u64))
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(4 as u64))
-			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(q as u64)))
+			.saturating_add((8_255_000 as Weight).saturating_mul(q as Weight))
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(q as Weight)))
 	}
 	// Storage: Fragments Definitions (r:1 w:1)
 	// Storage: Protos Protos (r:1 w:0)
@@ -123,11 +123,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `d` is `[1, 1000000]`.
 	fn mint_definition_that_has_unique_capability(d: u32, ) -> Weight {
-		Weight::from_ref_time(77_922_000 as u64)
+		(77_922_000 as Weight)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(d as u64))
-			.saturating_add(T::DbWeight::get().reads(8 as u64))
-			.saturating_add(T::DbWeight::get().writes(7 as u64))
+			.saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(T::DbWeight::get().reads(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments Definitions (r:1 w:1)
@@ -140,12 +140,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `q` is `[1, 100]`.
 	fn buy_definition_that_has_non_unique_capability(q: u32, ) -> Weight {
-		Weight::from_ref_time(49_276_000 as u64)
+		(49_276_000 as Weight)
 			// Standard Error: 32_000
-			.saturating_add(Weight::from_ref_time(7_485_000 as u64).saturating_mul(q as u64))
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(6 as u64))
-			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(q as u64)))
+			.saturating_add((7_485_000 as Weight).saturating_mul(q as Weight))
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(q as Weight)))
 	}
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments Definitions (r:1 w:1)
@@ -159,19 +159,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `d` is `[1, 1000000]`.
 	fn buy_definition_that_has_unique_capability(d: u32, ) -> Weight {
-		Weight::from_ref_time(33_800_000 as u64)
+		(33_800_000 as Weight)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(T::DbWeight::get().reads(8 as u64))
-			.saturating_add(T::DbWeight::get().writes(9 as u64))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(T::DbWeight::get().reads(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes(9 as Weight))
 	}
 	// Storage: Fragments Fragments (r:1 w:1)
 	// Storage: Fragments Inventory (r:2 w:2)
 	// Storage: Fragments Owners (r:2 w:2)
 	fn benchmark_give_instance_that_does_not_have_copy_perms() -> Weight {
-		Weight::from_ref_time(36_669_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().writes(5 as u64))
+		(36_669_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: Fragments Fragments (r:1 w:1)
 	// Storage: Fragments Inventory (r:2 w:1)
@@ -179,9 +179,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Fragments Owners (r:1 w:1)
 	// Storage: Fragments Expirations (r:1 w:1)
 	fn benchmark_give_instance_that_has_copy_perms() -> Weight {
-		Weight::from_ref_time(30_168_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(6 as u64))
-			.saturating_add(T::DbWeight::get().writes(5 as u64))
+		(30_168_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 }
 
@@ -195,11 +195,11 @@ impl WeightInfo for () {
 	// Storage: Fragments Proto2Fragments (r:1 w:1)
 	/// The range of component `n` is `[1, 100]`.
 	fn create(n: u32, ) -> Weight {
-		Weight::from_ref_time(53_058_000 as u64)
+		(53_058_000 as Weight)
 			// Standard Error: 9_000
-			.saturating_add(Weight::from_ref_time(10_000 as u64).saturating_mul(n as u64))
-			.saturating_add(RocksDbWeight::get().reads(6 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add((10_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:0)
 	// Storage: Protos Protos (r:1 w:0)
@@ -207,18 +207,18 @@ impl WeightInfo for () {
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments EditionsCount (r:1 w:0)
 	fn publish() -> Weight {
-		Weight::from_ref_time(34_050_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(34_050_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:0)
 	// Storage: Protos Protos (r:1 w:0)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Fragments Publishing (r:1 w:1)
 	fn unpublish() -> Weight {
-		Weight::from_ref_time(32_337_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(32_337_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Fragments Definitions (r:1 w:1)
 	// Storage: Protos Protos (r:1 w:0)
@@ -231,12 +231,12 @@ impl WeightInfo for () {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `q` is `[1, 100]`.
 	fn mint_definition_that_has_non_unique_capability(q: u32, ) -> Weight {
-		Weight::from_ref_time(36_569_000 as u64)
+		(36_569_000 as Weight)
 			// Standard Error: 133_000
-			.saturating_add(Weight::from_ref_time(8_255_000 as u64).saturating_mul(q as u64))
-			.saturating_add(RocksDbWeight::get().reads(7 as u64))
-			.saturating_add(RocksDbWeight::get().writes(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes((2 as u64).saturating_mul(q as u64)))
+			.saturating_add((8_255_000 as Weight).saturating_mul(q as Weight))
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(q as Weight)))
 	}
 	// Storage: Fragments Definitions (r:1 w:1)
 	// Storage: Protos Protos (r:1 w:0)
@@ -250,11 +250,11 @@ impl WeightInfo for () {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `d` is `[1, 1000000]`.
 	fn mint_definition_that_has_unique_capability(d: u32, ) -> Weight {
-		Weight::from_ref_time(77_922_000 as u64)
+		(77_922_000 as Weight)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(d as u64))
-			.saturating_add(RocksDbWeight::get().reads(8 as u64))
-			.saturating_add(RocksDbWeight::get().writes(7 as u64))
+			.saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments Definitions (r:1 w:1)
@@ -267,12 +267,12 @@ impl WeightInfo for () {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `q` is `[1, 100]`.
 	fn buy_definition_that_has_non_unique_capability(q: u32, ) -> Weight {
-		Weight::from_ref_time(49_276_000 as u64)
+		(49_276_000 as Weight)
 			// Standard Error: 32_000
-			.saturating_add(Weight::from_ref_time(7_485_000 as u64).saturating_mul(q as u64))
-			.saturating_add(RocksDbWeight::get().reads(7 as u64))
-			.saturating_add(RocksDbWeight::get().writes(6 as u64))
-			.saturating_add(RocksDbWeight::get().writes((2 as u64).saturating_mul(q as u64)))
+			.saturating_add((7_485_000 as Weight).saturating_mul(q as Weight))
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(q as Weight)))
 	}
 	// Storage: Fragments Publishing (r:1 w:1)
 	// Storage: Fragments Definitions (r:1 w:1)
@@ -286,19 +286,19 @@ impl WeightInfo for () {
 	// Storage: Fragments CopiesCount (r:0 w:1)
 	/// The range of component `d` is `[1, 1000000]`.
 	fn buy_definition_that_has_unique_capability(d: u32, ) -> Weight {
-		Weight::from_ref_time(33_800_000 as u64)
+		(33_800_000 as Weight)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(RocksDbWeight::get().reads(8 as u64))
-			.saturating_add(RocksDbWeight::get().writes(9 as u64))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(9 as Weight))
 	}
 	// Storage: Fragments Fragments (r:1 w:1)
 	// Storage: Fragments Inventory (r:2 w:2)
 	// Storage: Fragments Owners (r:2 w:2)
 	fn benchmark_give_instance_that_does_not_have_copy_perms() -> Weight {
-		Weight::from_ref_time(36_669_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().writes(5 as u64))
+		(36_669_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
 	// Storage: Fragments Fragments (r:1 w:1)
 	// Storage: Fragments Inventory (r:2 w:1)
@@ -306,8 +306,8 @@ impl WeightInfo for () {
 	// Storage: Fragments Owners (r:1 w:1)
 	// Storage: Fragments Expirations (r:1 w:1)
 	fn benchmark_give_instance_that_has_copy_perms() -> Weight {
-		Weight::from_ref_time(30_168_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(6 as u64))
-			.saturating_add(RocksDbWeight::get().writes(5 as u64))
+		(30_168_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
 }

--- a/pallets/protos/Cargo.toml
+++ b/pallets/protos/Cargo.toml
@@ -13,31 +13,31 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-keystore]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.12.0'
 optional = true
 
@@ -50,20 +50,20 @@ version = '3.0.0'
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 optional = true
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -74,7 +74,7 @@ version = '2.0'
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-detach]
@@ -88,37 +88,37 @@ path = '../accounts'
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-proxy]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-assets]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-primitives]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies]
@@ -129,7 +129,7 @@ serde = { version = "1.0.136", features = ["derive"], optional = true }
 serde_json = { version = '1.0.79', default-features = false, features = ['alloc'] }
 protos = { version = "0.1.16", default-features = false }
 base58 = { version = "0.2.0", default-features = false }
-ethabi = { version = "18.0.0", default-features = false }
+ethabi = { version = "17.0.0", default-features = false }
 
 # [dev-dependencies]
 # sp-clamor = { version = '0.1.0', path = '../../primitives/clamor'}

--- a/pallets/protos/rpc/Cargo.toml
+++ b/pallets/protos/rpc/Cargo.toml
@@ -21,22 +21,22 @@ protos = { version = "0.1.16", default-features = false }
 # Substrate Dependencies
 [dependencies.sp-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-rpc]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-blockchain]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-protos-rpc-runtime-api]

--- a/pallets/protos/rpc/runtime-api/Cargo.toml
+++ b/pallets/protos/rpc/runtime-api/Cargo.toml
@@ -18,20 +18,20 @@ sp-clamor = { version = '0.1.0', path = '../../../../primitives/clamor', default
 # Substrate Dependencies
 [dependencies.sp-api]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 default-features = false
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-protos]

--- a/pallets/protos/src/benchmarking.rs
+++ b/pallets/protos/src/benchmarking.rs
@@ -16,7 +16,7 @@ use crate::Pallet as Protos;
 
 const SEED: u32 = 0;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/protos/src/lib.rs
+++ b/pallets/protos/src/lib.rs
@@ -198,7 +198,6 @@ pub mod pallet {
 	use super::*;
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, Twox64Concat};
 	use frame_system::pallet_prelude::*;
-	use pallet_contracts::Determinism;
 	use pallet_detach::{
 		DetachHash, DetachRequest, DetachRequests, DetachedHashes, SupportedChains,
 	};
@@ -215,7 +214,7 @@ pub mod pallet {
 		+ pallet_contracts::Config
 	{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Weight functions needed for pallet_protos.
 		type WeightInfo: WeightInfo;
 
@@ -969,11 +968,10 @@ pub mod pallet {
 									who.clone(),
 									contract_address,
 									0u32.saturated_into(),
-									Weight::from_ref_time(1_000_000), // TODO determine this limit better should not be too high indeed
+									1_000_000, // TODO determine this limit better should not be too high indeed
 									None,
 									data,
 									false,
-									Determinism::Deterministic,
 								)
 								.result
 								.map_err(|e| {

--- a/pallets/protos/src/mock.rs
+++ b/pallets/protos/src/mock.rs
@@ -74,8 +74,8 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
+	type Origin = Origin;
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -83,7 +83,7 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::ed25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -96,7 +96,7 @@ impl frame_system::Config for Test {
 	type MaxConsumers = ConstU32<2>;
 }
 
-pub type Extrinsic = TestXt<RuntimeCall, ()>;
+pub type Extrinsic = TestXt<Call, ()>;
 type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 impl frame_system::offchain::SigningTypes for Test {
@@ -106,22 +106,22 @@ impl frame_system::offchain::SigningTypes for Test {
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
-	type OverarchingCall = RuntimeCall;
+	type OverarchingCall = Call;
 	type Extrinsic = Extrinsic;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
 where
-	RuntimeCall: From<LocalCall>,
+	Call: From<LocalCall>,
 {
 	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: RuntimeCall,
+		call: Call,
 		_public: <Signature as Verify>::Signer,
 		_account: AccountId,
 		nonce: u64,
-	) -> Option<(RuntimeCall, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
 		Some((call, (nonce, ())))
 	}
 }
@@ -136,7 +136,7 @@ impl pallet_randomness_collective_flip::Config for Test {}
 impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	/// The minimum amount required to keep an account open.
 	type ExistentialDeposit = ConstU128<500>;
 	type AccountStore = System;
@@ -152,7 +152,7 @@ parameter_types! {
 }
 
 impl pallet_accounts::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type EthChainId = ConstU64<5>; // goerli
 	type EthFragContract = ();
@@ -173,7 +173,7 @@ parameter_types! {
 	pub const MetadataDepositPerByte: Balance = 1 * DOLLARS;
 }
 impl pallet_assets::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type Balance = Balance;
 	type AssetId = u64;
 	type Currency = Balances;
@@ -187,11 +187,10 @@ impl pallet_assets::Config for Test {
 	type Freezer = ();
 	type WeightInfo = ();
 	type Extra = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 }
 
 impl pallet_protos::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type StorageBytesMultiplier = StorageBytesMultiplier;
 	type CurationExpiration = ConstU64<5>;
@@ -199,7 +198,7 @@ impl pallet_protos::Config for Test {
 }
 
 impl pallet_detach::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
+	type Event = Event;
 	type WeightInfo = ();
 	type AuthorityId = pallet_detach::crypto::DetachAuthId;
 }
@@ -213,8 +212,8 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl pallet_proxy::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
+	type Event = Event;
+	type Call = Call;
 	type Currency = ();
 	type ProxyType = ();
 	type ProxyDepositBase = ConstU32<1>;
@@ -228,7 +227,7 @@ impl pallet_proxy::Config for Test {
 }
 
 parameter_types! {
-	pub const DeletionWeightLimit: Weight = Weight::from_ref_time(500_000_000_000);
+	pub const DeletionWeightLimit: Weight = 500_000_000_000;
 	pub MySchedule: pallet_contracts::Schedule<Test> = {
 		let mut schedule = <pallet_contracts::Schedule<Test>>::default();
 		// We want stack height to be always enabled for tests so that this
@@ -238,14 +237,16 @@ parameter_types! {
 	};
 	pub static DepositPerByte: u64 = 1;
 	pub const DepositPerItem: u64 = 2;
+	pub BlockWeights: frame_system::limits::BlockWeights =
+		frame_system::limits::BlockWeights::simple_max(2 * WEIGHT_PER_SECOND);
 }
 
 impl pallet_contracts::Config for Test {
 	type Time = Timestamp;
 	type Randomness = CollectiveFlip;
 	type Currency = Balances;
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
+	type Event = Event;
+	type Call = Call;
 	type CallFilter = frame_support::traits::Nothing;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
@@ -257,7 +258,9 @@ impl pallet_contracts::Config for Test {
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = MySchedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
+	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<BlockWeights>;
 	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
+	type RelaxedMaxCodeLen = ConstU32<{ 256 * 1024 }>;
 	type MaxStorageKeyLen = ConstU32<128>;
 }
 

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -15,14 +15,14 @@ mod copied_from_pallet_accounts {
 
 	pub fn lock_(lock: &Lock) -> DispatchResult {
 		Accounts::internal_lock_update(
-			RuntimeOrigin::none(),
+			Origin::none(),
 			lock.data.clone(),
 			sp_core::ed25519::Signature([69u8; 64]), // this can be anything and it will still work
 		)
 	}
 
 	pub fn link_(link: &Link) -> DispatchResult {
-		Accounts::link(RuntimeOrigin::signed(link.clamor_account_id), link.link_signature.clone())
+		Accounts::link(Origin::signed(link.clamor_account_id), link.link_signature.clone())
 	}
 }
 
@@ -34,7 +34,7 @@ mod upload_tests {
 		proto: &ProtoFragment,
 	) -> DispatchResult {
 		ProtosPallet::upload(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			proto.references.clone(),
 			proto.category.clone(),
 			proto.tags.clone(),
@@ -97,7 +97,7 @@ mod upload_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_protos::Event::Uploaded {
+				mock::Event::from(pallet_protos::Event::Uploaded {
 					proto_hash: proto.get_proto_hash(),
 					cid: proto.get_proto_cid()
 				})
@@ -178,7 +178,7 @@ mod patch_tests {
 
 	fn patch_(signer: <Test as frame_system::Config>::AccountId, patch: &Patch) -> DispatchResult {
 		ProtosPallet::patch(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			patch.proto_fragment.clone().get_proto_hash(),
 			patch.include_cost.map(|cost| UsageLicense::Tickets(Compact::from(cost))),
 			patch.new_references.clone(),
@@ -219,7 +219,7 @@ mod patch_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_protos::Event::Patched {
+				mock::Event::from(pallet_protos::Event::Patched {
 					proto_hash: patch.proto_fragment.get_proto_hash(),
 					cid: patch.get_data_cid()
 				})
@@ -361,7 +361,7 @@ mod transfer_tests {
 		proto: &ProtoFragment,
 		new_owner: <Test as frame_system::Config>::AccountId,
 	) -> DispatchResult {
-		ProtosPallet::transfer(RuntimeOrigin::signed(signer), proto.get_proto_hash(), new_owner)
+		ProtosPallet::transfer(Origin::signed(signer), proto.get_proto_hash(), new_owner)
 	}
 
 	#[test]
@@ -396,7 +396,7 @@ mod transfer_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_protos::Event::Transferred {
+				mock::Event::from(pallet_protos::Event::Transferred {
 					proto_hash: proto.get_proto_hash(),
 					owner_id: dd.account_id_second
 				})
@@ -449,7 +449,7 @@ mod set_metadata_tests {
 		metadata: &Metadata,
 	) -> DispatchResult {
 		ProtosPallet::set_metadata(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			metadata.proto_fragment.get_proto_hash(),
 			metadata.metadata_key.clone(),
 			metadata.data.clone(),
@@ -485,7 +485,7 @@ mod set_metadata_tests {
 				.event;
 			assert_eq!(
 				event,
-				mock::RuntimeEvent::from(pallet_protos::Event::MetadataChanged {
+				mock::Event::from(pallet_protos::Event::MetadataChanged {
 					proto_hash: metadata.proto_fragment.get_proto_hash(),
 					cid: metadata.metadata_key.clone()
 				})
@@ -530,7 +530,7 @@ mod detach_tests {
 		detach: &Detach,
 	) -> DispatchResult {
 		ProtosPallet::detach(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			detach.proto_fragment.get_proto_hash(),
 			detach.target_chain,
 			detach.target_account.clone()
@@ -614,7 +614,7 @@ mod stake_tests {
 		stake_amount: &<Test as pallet_assets::Config>::Balance,
 	) -> DispatchResult {
 		ProtosPallet::curate(
-			RuntimeOrigin::signed(signer),
+			Origin::signed(signer),
 			proto.get_proto_hash(),
 			stake_amount.clone(),
 		)
@@ -667,7 +667,7 @@ mod stake_tests {
 			// 	.event;
 			// assert_eq!(
 			// 	event,
-			// 	mock::RuntimeEvent::from(pallet_protos::Event::Staked {
+			// 	mock::Event::from(pallet_protos::Event::Staked {
 			// 		proto_hash: stake.proto_fragment.get_proto_hash(),
 			// 		account_id: dd.account_id,
 			// 		balance: stake.get_stake_amount()
@@ -1595,7 +1595,7 @@ mod ban_tests {
 	use super::*;
 
 	pub fn ban(proto: &ProtoFragment) -> DispatchResult {
-		ProtosPallet::ban(RuntimeOrigin::root(), proto.get_proto_hash())
+		ProtosPallet::ban(Origin::root(), proto.get_proto_hash())
 	}
 
 	#[test]
@@ -1630,7 +1630,7 @@ mod ban_tests {
 			let proto = dd.proto_fragment;
 			assert_ok!(upload(dd.account_id, &proto));
 			assert_noop!(
-				ProtosPallet::ban(RuntimeOrigin::signed(dd.account_id), proto.get_proto_hash()),
+				ProtosPallet::ban(Origin::signed(dd.account_id), proto.get_proto_hash()),
 				sp_runtime::DispatchError::BadOrigin
 			);
 		});

--- a/pallets/protos/src/weights.rs
+++ b/pallets/protos/src/weights.rs
@@ -66,18 +66,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `t` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn upload(r: u32, t: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(95_041_000 as u64)
+		(95_041_000 as Weight)
 			// Standard Error: 65_000
-			.saturating_add(Weight::from_ref_time(2_092_000 as u64).saturating_mul(r as u64))
+			.saturating_add((2_092_000 as Weight).saturating_mul(r as Weight))
 			// Standard Error: 65_000
-			.saturating_add(Weight::from_ref_time(2_860_000 as u64).saturating_mul(t as u64))
+			.saturating_add((2_860_000 as Weight).saturating_mul(t as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(t as u64)))
-			.saturating_add(T::DbWeight::get().writes(4 as u64))
-			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(t as u64)))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(t as Weight)))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(t as Weight)))
 	}
 	// Storage: Protos Protos (r:2 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
@@ -88,34 +88,34 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `t` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn patch(r: u32, t: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		(0 as Weight)
 			// Standard Error: 198_000
-			.saturating_add(Weight::from_ref_time(2_254_000 as u64).saturating_mul(r as u64))
+			.saturating_add((2_254_000 as Weight).saturating_mul(r as Weight))
 			// Standard Error: 198_000
-			.saturating_add(Weight::from_ref_time(3_096_000 as u64).saturating_mul(t as u64))
+			.saturating_add((3_096_000 as Weight).saturating_mul(t as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(t as u64)))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
-			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(t as u64)))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(t as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(t as Weight)))
 	}
 	// Storage: Protos Protos (r:1 w:0)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Detach DetachRequests (r:1 w:1)
 	fn detach() -> Weight {
-		Weight::from_ref_time(13_387_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
+		(13_387_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Protos Protos (r:1 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Protos ProtosByOwner (r:2 w:2)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(24_381_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+		(24_381_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Protos Protos (r:1 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
@@ -125,13 +125,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `m` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn set_metadata(m: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		(0 as Weight)
 			// Standard Error: 90_000
-			.saturating_add(Weight::from_ref_time(122_000 as u64).saturating_mul(m as u64))
+			.saturating_add((122_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 }
 
@@ -147,18 +147,18 @@ impl WeightInfo for () {
 	/// The range of component `t` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn upload(r: u32, t: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(95_041_000 as u64)
+		(95_041_000 as Weight)
 			// Standard Error: 65_000
-			.saturating_add(Weight::from_ref_time(2_092_000 as u64).saturating_mul(r as u64))
+			.saturating_add((2_092_000 as Weight).saturating_mul(r as Weight))
 			// Standard Error: 65_000
-			.saturating_add(Weight::from_ref_time(2_860_000 as u64).saturating_mul(t as u64))
+			.saturating_add((2_860_000 as Weight).saturating_mul(t as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(t as u64)))
-			.saturating_add(RocksDbWeight::get().writes(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(t as u64)))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(t as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(t as Weight)))
 	}
 	// Storage: Protos Protos (r:2 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
@@ -169,34 +169,34 @@ impl WeightInfo for () {
 	/// The range of component `t` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn patch(r: u32, t: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		(0 as Weight)
 			// Standard Error: 198_000
-			.saturating_add(Weight::from_ref_time(2_254_000 as u64).saturating_mul(r as u64))
+			.saturating_add((2_254_000 as Weight).saturating_mul(r as Weight))
 			// Standard Error: 198_000
-			.saturating_add(Weight::from_ref_time(3_096_000 as u64).saturating_mul(t as u64))
+			.saturating_add((3_096_000 as Weight).saturating_mul(t as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(t as u64)))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
-			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(t as u64)))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(t as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(t as Weight)))
 	}
 	// Storage: Protos Protos (r:1 w:0)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Detach DetachRequests (r:1 w:1)
 	fn detach() -> Weight {
-		Weight::from_ref_time(13_387_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(3 as u64))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+		(13_387_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Protos Protos (r:1 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
 	// Storage: Protos ProtosByOwner (r:2 w:2)
 	fn transfer() -> Weight {
-		Weight::from_ref_time(24_381_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+		(24_381_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: Protos Protos (r:1 w:1)
 	// Storage: Detach DetachedHashes (r:1 w:0)
@@ -206,12 +206,12 @@ impl WeightInfo for () {
 	/// The range of component `m` is `[1, 100]`.
 	/// The range of component `d` is `[1, 1000000]`.
 	fn set_metadata(m: u32, d: u32, ) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		(0 as Weight)
 			// Standard Error: 90_000
-			.saturating_add(Weight::from_ref_time(122_000 as u64).saturating_mul(m as u64))
+			.saturating_add((122_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(d as u64))
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 }

--- a/primitives/clamor/Cargo.toml
+++ b/primitives/clamor/Cargo.toml
@@ -20,31 +20,31 @@ version = '3.0.0'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 optional = true
 
 [dependencies.sp-runtime-interface]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.scale-info]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,7 +14,7 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-wasm-builder]
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '5.0.0-dev'
 
 [dependencies.codec]
@@ -27,38 +27,38 @@ version = '3.0.0'
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
 optional = true
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-executive]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-benchmarking]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
 optional = true
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-rpc-runtime-api]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.hex-literal]
@@ -68,55 +68,55 @@ version = '0.3.1'
 [dependencies.pallet-assets]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-aura]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-grandpa]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-sudo]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc-runtime-api]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -127,67 +127,67 @@ version = '2.0'
 [dependencies.sp-api]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-consensus-aura]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-inherents]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-offchain]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
 
 [dependencies.sp-session]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-transaction-pool]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.sp-version]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '5.0.0'
 
 [dependencies.pallet-accounts]
@@ -223,43 +223,49 @@ version = '0.0.1'
 [dependencies.pallet-indices]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-primitives]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '6.0.0'
+
+[dependencies.pallet-contracts-rpc-runtime-api]
+default-features = false
+git = 'https://github.com/fragcolor-xyz/substrate.git'
+tag = 'fragnova-v0.0.6'
+version = '4.0.0-dev'
 
 [dependencies.pallet-multisig]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-proxy]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-identity]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies.pallet-utility]
 default-features = false
 git = 'https://github.com/fragcolor-xyz/substrate.git'
-tag = 'fragnova-v0.9.33-1'
+tag = 'fragnova-v0.0.6'
 version = '4.0.0-dev'
 
 [dependencies]
@@ -324,6 +330,7 @@ std = [
     'pallet-indices/std',
     'pallet-contracts/std',
     'pallet-contracts-primitives/std',
+    'pallet-contracts-rpc-runtime-api/std',
     'pallet-multisig/std',
     "pallet-proxy/std",
     "pallet-identity/std",

--- a/shards/fragnova.edn
+++ b/shards/fragnova.edn
@@ -112,6 +112,9 @@
 
    (Do get-node-genesis-hash) (ExpectBytes) = .node-genesis-hash ; ensure the node is up and running
 
+    ; so this is not ideal but we want to pause a bit to let the node start up all services
+   (Pause 5.0)
+
    0 >== .fragnova-rpc-index ; make it global so Spawn won't copy it ; `.fragnova-rpc-index` is the number of RPC calls made so far by the account
 
    (get Fragnova-Account :private-key) (Sr25519.PublicKey) (Substrate.AccountId) = .pub-key

--- a/shards/run-test-ipfs.edn
+++ b/shards/run-test-ipfs.edn
@@ -12,9 +12,7 @@
 
   .call-data (Do (get Fragnova-Node :send-signed-extrinsic-as-http-request)) (Log "HTTP Response of protos.upload() is")
 
-  .proto-data (Hash.Blake2-256) (| (ToHex) (Log "Uploaded Proto With Proto Hash"))
-
-  )
+  .proto-data (Hash.Blake2-256) (| (ToHex) (Log "Uploaded Proto With Proto Hash")))
 
 
 (defwire convert-blake256-hash-to-ipfs-cid
@@ -24,16 +22,13 @@
   "0x0155a0e40220" (HexToBytes) (PrependTo .proto-hash-duplicate)
   .proto-hash-duplicate (ToBase58) >= .ipfs-cid
   "z" (PrependTo .ipfs-cid)
-  .ipfs-cid (Log "IPFS CID")
-
-  )
+  .ipfs-cid (Log "IPFS CID"))
 
 (defwire get-clamor-p2p-addresses
 
   {"id" 1 "jsonrpc" "2.0" "method" "system_localListenAddresses" "params" []} (ToJson) (Http.Post RPC-SERVER) ; `system_localListenAddresses` return the string representation of the addresses we listen on, including the trailing /p2p/.
   (FromJson) (ExpectTable) (Take "result")
-  (ExpectStringSeq) (Log "Clamor is listening to the following P2P addresses")
-  )
+  (ExpectStringSeq) (Log "Clamor is listening to the following P2P addresses"))
 
 (defwire connect-to-clamor-p2p-addresses
 
@@ -47,13 +42,12 @@
    (->
     (Log "connecting to p2p address")
     = .p2p-address
-    ["swarm" "peering" "add" .p2p-address] = .ipfs-args
+    ["swarm" "peering" "add" .p2p-address] >= .ipfs-args
     "" (Process.Run :Executable "ipfs" :Arguments .ipfs-args)
-    )
-   )
+    ["swarm" "connect" .p2p-address] > .ipfs-args
+    "" (Process.Run :Executable "ipfs" :Arguments .ipfs-args)))
 
   (Maybe (-> "" (Process.Run :Executable "ipfs" :Arguments ["repo" "gc"]) nil)) ;  `ipfs repo gc` - Performs a garbage collection sweep on the IPFS Repo.
-
   )
 
 (defwire call-ipfs-block-get
@@ -63,27 +57,23 @@
 
   ["block" "get" .proto-hash-cid] = .ipfs-args
   "" (Process.Run "ipfs" :Arguments .ipfs-args :Timeout 120) (StringToBytes) ; `ipfs block` - Interact with raw IPFS blocks. A block is identified by a Multihash passed with a valid CID.
-
   )
 
 (defwire main
   (Setup
-   (get Fragnova-Node :setup)
-   )
+   (get Fragnova-Node :setup))
 
   "Proto-Indo-European" (ToBytes) = .proto-data
   (Do upload-proto) = .proto-hash
   (Do convert-blake256-hash-to-ipfs-cid) = .proto-hash-cid
   (Do get-clamor-p2p-addresses) = .clamor-p2p-addresses
-  (Do connect-to-clamor-p2p-addresses)
+  (Do connect-to-clamor-p2p-addresses) (Assert.IsNot 0)
 
   ; not ideal but we need to wait transaction is done and CI can be slow
   (Pause 5.0)
 
-  (Do call-ipfs-block-get) (Log "ipfs block is")  (Is .proto-data) (Assert.Is true)
-
-  )
+  (Do call-ipfs-block-get) (Log "ipfs block is")  (Is .proto-data))
 
 (defmesh root)
 (schedule root main)
-(run root 0.1)
+(if (run root 0.1) nil (throw "Root tick failed"))

--- a/shards/test-ipfs.sh
+++ b/shards/test-ipfs.sh
@@ -4,9 +4,9 @@ set -e
 # INSTALL IPFS
 apt-get update
 apt-get install -y wget
-wget -q https://dist.ipfs.tech/kubo/v0.16.0/kubo_v0.16.0_linux-amd64.tar.gz
-tar -xvzf kubo_v0.16.0_linux-amd64.tar.gz
-export PATH=$PATH:`pwd`/kubo
+wget -q https://dist.ipfs.tech/go-ipfs/v0.12.0/go-ipfs_v0.12.0_linux-amd64.tar.gz
+tar -xvzf go-ipfs_v0.12.0_linux-amd64.tar.gz
+export PATH=$PATH:`pwd`/go-ipfs
 
 # RUN IPFS
 ipfs init # Initializes ipfs configuration files and generates a new keypair. (https://docs.ipfs.tech/how-to/command-line-quick-start/#initialize-the-repository)


### PR DESCRIPTION
Rollback needed after IPFS issues [introduced](https://github.com/fragcolor-xyz/substrate/commit/50325f1f0b36210d1730f7c903ab89083fe37a05) with Substrate tag `fragnova-v0.29.1`.

Rolled back to this tag where IPFS works with `go-ipfs_v0.12.0`.