### PR TITLE
Bounded all extrinsics' `Vec` params, if the `Vec` param is stored into state

### DIFF
--- a/pallets/accounts/src/benchmarking.rs
+++ b/pallets/accounts/src/benchmarking.rs
@@ -7,7 +7,7 @@ use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
 use sp_io::hashing::keccak_256;
-use sp_runtime::SaturatedConversion;
+use sp_runtime::{SaturatedConversion, traits::Zero};
 use sp_std::collections::btree_set::BTreeSet;
 
 use crate::Pallet as Accounts;

--- a/pallets/accounts/src/dummy_data.rs
+++ b/pallets/accounts/src/dummy_data.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 use crate::*;
 
-use codec::Encode;
 use ethabi::ethereum_types::{Address};
 
 use sp_core::{
@@ -55,6 +54,7 @@ fn get_ethereum_chain_id() -> u64 {
 
 #[cfg(test)]
 fn get_genesis_hash() -> sp_core::H256 {
+	use sp_runtime::traits::Zero;
 	use crate::mock::Test;
 	<frame_system::Pallet<Test>>::block_hash(<Test as frame_system::Config>::BlockNumber::zero())
 }

--- a/pallets/accounts/src/lib.rs
+++ b/pallets/accounts/src/lib.rs
@@ -40,7 +40,7 @@ const LINK_VERIFYING_CONTRACT: &str = "f5a0af5a0af5a0af5a0af5a0af5a0af5a0af5a0a"
 
 use sp_core::{crypto::KeyTypeId, ecdsa, ed25519, H256};
 
-use ethabi::ethereum_types::{Address, H160, U256};
+use ethabi::ethereum_types::{H160, U256};
 
 /// Defines application identifier for crypto keys of this module.
 ///
@@ -96,7 +96,7 @@ use sp_io::{
 	crypto as Crypto,
 	hashing::{blake2_256, keccak_256},
 };
-use sp_runtime::{offchain::storage::StorageValueRef, traits::Zero, MultiSigner};
+use sp_runtime::{offchain::storage::StorageValueRef, MultiSigner};
 use sp_std::{collections::btree_set::BTreeSet, vec, vec::Vec};
 
 use frame_system::offchain::{

--- a/pallets/fragments/src/benchmarking.rs
+++ b/pallets/fragments/src/benchmarking.rs
@@ -5,7 +5,7 @@
 use super::*;
 use frame_benchmarking::{account, benchmarks, vec, whitelisted_caller};
 use frame_system::RawOrigin;
-use frame_support::{BoundedVec};
+use frame_support::{BoundedVec, traits::Get};
 use pallet_protos::UsageLicense;
 use protos::{
 	categories::{Categories, TextCategories},
@@ -22,7 +22,6 @@ use pallet_protos::Pallet as Protos;
 const SEED: u32 = 0;
 
 const MAX_DATA_LENGTH: u32 = 1_000_000; // 1 MegaByte
-const MAX_METADATA_NAME_LENGTH: u32 = 100;
 const MAX_QUANTITY_TO_MINT: u32 = 100;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
@@ -38,8 +37,6 @@ benchmarks! {
 	}
 
 	create { // Benchmark setup phase
-		let n in 1 .. MAX_METADATA_NAME_LENGTH; // `metadata.name` length
-
 		// `whitelisted_caller()`'s DB operations will not be counted when we run the extrinsic
 		let caller: T::AccountId = whitelisted_caller();
 
@@ -65,7 +62,7 @@ benchmarks! {
 		let proto_hash = blake2_256(&proto_data);
 
 		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
-			name: vec![7u8; n as usize].try_into().unwrap(),
+			name: vec![7u8; <T as pallet_protos::Config>::StringLimit::get() as usize].try_into().unwrap(),
 			// By making currency `Currency::Custom`, we enter an extra if-statement and also do an extra DB read operation
 			currency: Currency::Custom(T::AssetId::default()),
 		};

--- a/pallets/fragments/src/benchmarking.rs
+++ b/pallets/fragments/src/benchmarking.rs
@@ -5,6 +5,7 @@
 use super::*;
 use frame_benchmarking::{account, benchmarks, vec, whitelisted_caller};
 use frame_system::RawOrigin;
+use frame_support::{BoundedVec};
 use pallet_protos::UsageLicense;
 use protos::{
 	categories::{Categories, TextCategories},
@@ -56,15 +57,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: vec![7u8; n as usize],
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: vec![7u8; n as usize].try_into().unwrap(),
 			// By making currency `Currency::Custom`, we enter an extra if-statement and also do an extra DB read operation
 			currency: Currency::Custom(T::AssetId::default()),
 		};
@@ -88,15 +89,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -131,15 +132,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -176,15 +177,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -226,15 +227,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -275,15 +276,15 @@ benchmarks! {
 			RawOrigin::Signed(definition_owner.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -341,15 +342,15 @@ benchmarks! {
 			RawOrigin::Signed(definition_owner.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -405,15 +406,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(
@@ -470,15 +471,15 @@ benchmarks! {
 			RawOrigin::Signed(caller.clone()).into(),
 			Vec::<Hash256>::new(),
 			Categories::Text(TextCategories::Plain),
-			Vec::<Vec<u8>>::new(),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata = DefinitionMetadata {
-			name: b"Je suis un Nom".to_vec(),
+		let metadata = DefinitionMetadata::<BoundedVec<u8, _>, _> {
+			name: b"Je suis un Nom".to_vec().try_into().unwrap(),
 			currency: Currency::Native,
 		};
 		Fragments::<T>::create(

--- a/pallets/fragments/src/dummy_data.rs
+++ b/pallets/fragments/src/dummy_data.rs
@@ -56,7 +56,7 @@ pub struct Definition {
 	// "Definition" is short for "Fragment Definition"
 	pub proto_fragment: ProtoFragment,
 
-	pub metadata: DefinitionMetadata<u64>,
+	pub metadata: DefinitionMetadata<Vec<u8>, u64>,
 	pub permissions: FragmentPerms,
 
 	pub unique: Option<UniqueOptions>,

--- a/pallets/fragments/src/lib.rs
+++ b/pallets/fragments/src/lib.rs
@@ -543,6 +543,8 @@ pub mod pallet {
 		ProtoOwnerNotFound,
 		/// No Permission
 		NoPermission,
+		/// Detach Request's Target Account is empty
+		DetachAccountIsEmpty,
 		/// Detach Request Already Submitted
 		DetachRequestAlreadyExists,
 		/// Already detached
@@ -575,6 +577,10 @@ pub mod pallet {
 		UniqueDataExists,
 		/// Currency not found
 		CurrencyNotFound,
+		/// Fragment Definition's Metadata key is empty
+		DefinitionMetadataKeyIsEmpty,
+		/// Fragment Instance's Metadata key is empty
+		InstanceMetadataKeyIsEmpty,
 	}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -716,6 +722,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			ensure!(!metadata_key.is_empty(), Error::<T>::DefinitionMetadataKeyIsEmpty);
+
 			let proto_hash =
 				<Definitions<T>>::get(definition_hash).ok_or(Error::<T>::NotFound)?.proto_hash; // Get `proto_hash` from `definition_hash`
 			let proto: Proto<T::AccountId, T::BlockNumber> =
@@ -801,6 +809,8 @@ pub mod pallet {
 			data: Vec<u8>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			ensure!(!metadata_key.is_empty(), Error::<T>::InstanceMetadataKeyIsEmpty);
 
 			ensure!(!<DetachedHashes<T>>::contains_key(&DetachHash::Instance(definition_hash, Compact(edition_id), Compact(copy_id))), Error::<T>::Detached);
 
@@ -1387,6 +1397,8 @@ pub mod pallet {
 		) -> DispatchResult {
 
 			let who = ensure_signed(origin)?;
+
+			ensure!(!target_account.is_empty(), Error::<T>::DetachAccountIsEmpty);
 
 			let current_block_number = <frame_system::Pallet<T>>::block_number();
 

--- a/pallets/fragments/src/mock.rs
+++ b/pallets/fragments/src/mock.rs
@@ -204,6 +204,9 @@ parameter_types! {
 impl pallet_protos::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
+	type StringLimit = StringLimit;
+	type DetachAccountLimit = ConstU32<20>;
+	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
 	type CurationExpiration = ConstU64<5>;
 	type TicketsAssetId = TicketsAssetId;

--- a/pallets/protos/src/benchmarking.rs
+++ b/pallets/protos/src/benchmarking.rs
@@ -22,9 +22,7 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 }
 
 const MAX_REFERENCES_LENGTH: u32 = 100;
-const MAX_TAGS_LENGTH: u32 = 100;
 const MAX_DATA_LENGTH: u32 = 1_000_000; // 1 MegaByte
-const MAX_METADATA_KEY_LENGTH: u32 = 100;
 
 benchmarks! {
 
@@ -34,7 +32,6 @@ benchmarks! {
 
 	upload {
 		let r in 1 .. MAX_REFERENCES_LENGTH; // `references` length
-		let t in 1 .. MAX_TAGS_LENGTH; // `tags` length
 		let d in 1 .. MAX_DATA_LENGTH; // `data` length
 		// `whitelisted_caller()` is a special function from `frame_benchmark`
 		// that returns an account whose DB operations (for e.g taking the fee from the account, or updating the nonce)
@@ -56,7 +53,7 @@ benchmarks! {
 			Ok(proto_hash)
 		}).collect::<Result::<Vec<Hash256>, _>>()?;
 		let category = Categories::Text(TextCategories::Plain);
-		let tags: BoundedVec::<BoundedVec<u8, _>, _> = (0 .. t).into_iter().map(|i| {
+		let tags: BoundedVec::<BoundedVec<u8, _>, _> = (0 .. T::MaxTags::get()).into_iter().map(|i| {
 			format!("{}", i).repeat(<T as pallet::Config>::StringLimit::get() as usize).into_bytes()[0..<T as pallet::Config>::StringLimit::get() as usize].to_vec().try_into().unwrap()
 		}).collect::<Vec<BoundedVec<u8, _>>>().try_into().unwrap();
 		let linked_asset: Option<LinkedAsset> = None;
@@ -74,7 +71,6 @@ benchmarks! {
 
 	patch {
 		let r in 1 .. MAX_REFERENCES_LENGTH; // `new_references` length
-		let t in 1 .. MAX_TAGS_LENGTH; // `new_tags` length
 		let d in 1 .. MAX_DATA_LENGTH; // `data` length
 		let caller: T::AccountId = whitelisted_caller();
 
@@ -105,7 +101,7 @@ benchmarks! {
 			Ok(proto_hash)
 		}).collect::<Result::<Vec<Hash256>, _>>()?;
 		let new_tags: Option::<BoundedVec::<BoundedVec<u8, _>, _>> = Some(
-			(0 .. t).into_iter().map(|i| {
+			(0 .. T::MaxTags::get()).into_iter().map(|i| {
 				format!("{}", i).repeat(<T as pallet::Config>::StringLimit::get() as usize).into_bytes()[0..<T as pallet::Config>::StringLimit::get() as usize].to_vec().try_into().unwrap()
 			}).collect::<Vec<BoundedVec<u8, _>>>().try_into().unwrap()
 		);
@@ -125,20 +121,26 @@ benchmarks! {
 	detach {
 		let caller: T::AccountId = whitelisted_caller();
 
-		let mut immutable_data: [u8; 9] = [0; 9];
-		hex::decode_to_slice("010000000b00803103", &mut immutable_data).unwrap();
-		let immutable_data = immutable_data.to_vec();
-		let proto_hash = blake2_256(immutable_data.as_slice());
-		let references = vec![];
+		let proto_data = b"Je suis Data".to_vec();
+		Protos::<T>::upload(
+			RawOrigin::Signed(caller.clone()).into(),
+			Vec::<Hash256>::new(),
+			Categories::Text(TextCategories::Plain),
+			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
+			None,
+			UsageLicense::Closed,
+			proto_data.clone()
+		)?;
+		let proto_hash = blake2_256(&proto_data);
 
-		Protos::<T>::upload(RawOrigin::Signed(caller.clone()).into(), references, Categories::Text(TextCategories::Plain), Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(), None, UsageLicense::Closed, immutable_data.clone())?;
+		let target_chain = pallet_detach::SupportedChains::EthereumMainnet;
+		let target_account: BoundedVec<u8, _> = vec![7u8; T::DetachAccountLimit::get() as usize].try_into().unwrap();
 
-		let public: [u8; 33] = [2, 44, 133, 69, 18, 57, 0, 152, 97, 145, 160, 85, 122, 14, 119, 232, 88, 169, 142, 77, 139, 133, 214, 67, 188, 128, 137, 28, 23, 247, 242, 193, 104];
-		let target_account: Vec<u8> = [203, 109, 249, 222, 30, 252, 167, 163, 153, 138, 142, 173, 78, 2, 21, 157, 95, 169, 156, 62, 13, 79, 214, 67, 38, 103, 57, 11, 180, 114, 104, 84].to_vec();
-		Detach::<T>::add_eth_auth(RawOrigin::Root.into(), sp_core::ecdsa::Public::from_raw(public))?;
+		// Detach::<T>::add_eth_auth(RawOrigin::Root.into(), sp_core::ecdsa::Public::from_raw(public))?;
 
 		let pre_len: usize = <pallet_detach::DetachRequests<T>>::get().len();
-	}: _(RawOrigin::Signed(caller), proto_hash, pallet_detach::SupportedChains::EthereumMainnet, target_account.try_into().unwrap())
+
+	}: _(RawOrigin::Signed(caller), proto_hash, target_chain, target_account)
 	verify {
 		assert_eq!(<pallet_detach::DetachRequests<T>>::get().len(), pre_len + 1 as usize);
 	}
@@ -165,7 +167,6 @@ benchmarks! {
 	}
 
 	set_metadata { // Benchmark setup phase
-		let m in 1 .. MAX_METADATA_KEY_LENGTH; // `metadata_key` length
 		let d in 1 .. MAX_DATA_LENGTH; // 1 byte to 1 Megabyte (I tried 1 byte to 1 Gigabyte, but I got the error: Thread 'main' panicked at 'Failed to allocate memory: "Requested allocation size is too large"', /Users/home/.cargo/git/checkouts/substrate-c784a31f8dac2358/401804d/primitives/io/src/lib.rs:1382)
 
 		// `whitelisted_caller()`'s DB operations will not be counted when we run the extrinsic
@@ -183,12 +184,12 @@ benchmarks! {
 		)?;
 		let proto_hash = blake2_256(&proto_data);
 
-		let metadata_key: Vec<u8> = vec![7u8; m as usize];
+		let metadata_key: BoundedVec<u8, _> = vec![7u8; <T as pallet::Config>::StringLimit::get() as usize].try_into().unwrap();
 		let data: Vec<u8> = vec![7u8; d as usize];
 
-	}: set_metadata(RawOrigin::Signed(caller), proto_hash.clone(), metadata_key.clone().try_into().unwrap(), data) // Execution phase
+	}: set_metadata(RawOrigin::Signed(caller), proto_hash.clone(), metadata_key.clone(), data) // Execution phase
 	verify { // Optional verification phase
-		assert_last_event::<T>(Event::<T>::MetadataChanged { proto_hash: proto_hash, metadata_key: metadata_key }.into())
+		assert_last_event::<T>(Event::<T>::MetadataChanged { proto_hash: proto_hash, metadata_key: metadata_key.into() }.into())
 	}
 
 	impl_benchmark_test_suite!(Protos, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/protos/src/benchmarking.rs
+++ b/pallets/protos/src/benchmarking.rs
@@ -132,6 +132,7 @@ benchmarks! {
 			Vec::<BoundedVec<u8, _>>::new().try_into().unwrap(),
 			None,
 			UsageLicense::Closed,
+			None,
 			proto_data.clone()
 		)?;
 		let proto_hash = blake2_256(&proto_data);

--- a/pallets/protos/src/lib.rs
+++ b/pallets/protos/src/lib.rs
@@ -353,6 +353,12 @@ pub mod pallet {
 		ProtoNotFound,
 		/// Proto already uploaded
 		ProtoExists,
+		/// Proto data is empty
+		ProtoDataIsEmpty,
+		/// Proto-Fragment's Metadata key is empty
+		MetadataKeyIsEmpty,
+		/// Detach Request's Target Account is empty
+		DetachAccountIsEmpty,
 		/// Detach Request Already Submitted
 		DetachRequestAlreadyExists,
 		/// Already detached
@@ -409,6 +415,8 @@ pub mod pallet {
 			data: Vec<u8>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			ensure!(!data.is_empty(), Error::<T>::ProtoDataIsEmpty);
 
 			let current_block_number = <frame_system::Pallet<T>>::block_number();
 
@@ -729,6 +737,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			ensure!(!metadata_key.is_empty(), Error::<T>::MetadataKeyIsEmpty);
+
 			let proto: Proto<T::AccountId, T::BlockNumber> =
 				<Protos<T>>::get(&proto_hash).ok_or(Error::<T>::ProtoNotFound)?;
 
@@ -808,6 +818,8 @@ pub mod pallet {
 			target_account: BoundedVec<u8, T::DetachAccountLimit>, // an eth address or so
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			ensure!(!target_account.is_empty(), Error::<T>::DetachAccountIsEmpty);
 
 			// make sure the proto exists
 			let proto: Proto<T::AccountId, T::BlockNumber> =

--- a/pallets/protos/src/mock.rs
+++ b/pallets/protos/src/mock.rs
@@ -192,6 +192,9 @@ impl pallet_assets::Config for Test {
 impl pallet_protos::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
+	type StringLimit = StringLimit;
+	type DetachAccountLimit = ConstU32<20>;
+	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
 	type CurationExpiration = ConstU64<5>;
 	type TicketsAssetId = TicketsAssetId;

--- a/pallets/protos/src/tests.rs
+++ b/pallets/protos/src/tests.rs
@@ -27,6 +27,7 @@ mod copied_from_pallet_accounts {
 }
 
 mod upload_tests {
+	use sp_runtime::BoundedVec;
 	use super::*;
 
 	pub fn upload(
@@ -37,7 +38,14 @@ mod upload_tests {
 			Origin::signed(signer),
 			proto.references.clone(),
 			proto.category.clone(),
-			proto.tags.clone(),
+			TryInto::<BoundedVec<BoundedVec<_, _>, <Test as pallet_protos::Config>::MaxTags>>::try_into(
+				proto
+					.tags
+					.clone()
+					.into_iter()
+					.map(|tag: Vec<u8>| TryInto::<BoundedVec<u8, <Test as pallet_protos::Config>::StringLimit>>::try_into(tag).unwrap())
+					.collect::<Vec<BoundedVec<_, _>>>()
+			).unwrap(),
 			proto.linked_asset.clone(),
 			proto
 				.include_cost
@@ -451,7 +459,7 @@ mod set_metadata_tests {
 		ProtosPallet::set_metadata(
 			Origin::signed(signer),
 			metadata.proto_fragment.get_proto_hash(),
-			metadata.metadata_key.clone(),
+			metadata.metadata_key.clone().try_into().unwrap(),
 			metadata.data.clone(),
 		)
 	}
@@ -487,7 +495,7 @@ mod set_metadata_tests {
 				event,
 				mock::Event::from(pallet_protos::Event::MetadataChanged {
 					proto_hash: metadata.proto_fragment.get_proto_hash(),
-					cid: metadata.metadata_key.clone()
+					metadata_key: metadata.metadata_key.clone()
 				})
 			);
 		});
@@ -533,7 +541,7 @@ mod detach_tests {
 			Origin::signed(signer),
 			detach.proto_fragment.get_proto_hash(),
 			detach.target_chain,
-			detach.target_account.clone()
+			detach.target_account.clone().try_into().unwrap()
 		)
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -19,7 +19,7 @@ use frame_support::{
 	traits::{ConstU16, ConstU128, ConstU32, ConstU64},
 	weights::DispatchClass,
 };
-use frame_system::{EnsureRoot, EnsureSigned, limits::{BlockLength, BlockWeights},};
+use frame_system::{EnsureRoot, limits::{BlockLength, BlockWeights},};
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -60,7 +60,6 @@ pub use sp_runtime::{Perbill, Permill};
 use scale_info::prelude::string::String;
 
 use codec::Encode;
-use frame_support::traits::AsEnsureOriginWithArg;
 use sp_runtime::traits::{SaturatedConversion, StaticLookup};
 
 use pallet_fragments::{GetDefinitionsParams, GetInstanceOwnerParams, GetInstancesParams};
@@ -452,6 +451,9 @@ impl pallet_accounts::Config for Runtime {
 impl pallet_protos::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = ();
+	type StringLimit = StringLimit;
+	type DetachAccountLimit = ConstU32<20>; // An ethereum public account address has a length of 20.
+	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
 	type CurationExpiration = ConstU64<100800>; // one week
 	type TicketsAssetId = TicketsAssetId;


### PR DESCRIPTION
these are the bounding parameters:
- `pallet_protos::Config::StringLimit` for limiting string size (used by both `pallet_protos` and `pallet_fragments` - not sure if `pallet_fragments` should have its own Config @sinkingsugar @alebaffa 😅)
- `pallet_protos::Config::MaxTags` for limiting max number of proto tags
- `pallet_protos::Config::DetachAccountLimit` for limiting the maximum length that a detach account can be. (used by both `pallet_protos` and `pallet_fragments` - not sure if `pallet_fragments` should have its own Config @sinkingsugar @alebaffa 😅)

 