### PR TITLE
Optimize clusters and refactor edit_role

### DIFF
--- a/pallets/clusters/src/dummy_data.rs
+++ b/pallets/clusters/src/dummy_data.rs
@@ -21,10 +21,6 @@ pub struct DummyData {
 	pub account_id_2: Public,
 }
 
-pub fn get_role_hash(cluster_id: Hash128, role: Vec<u8>) -> Hash128 {
-	blake2_128(&[&cluster_id[..], &role.clone()[..]].concat())
-}
-
 pub fn get_cluster_id(cluster_name: Vec<u8>, account_id: sp_core::ed25519::Public, index: u32) -> Hash128 {
 	let extrinsic_index = 2;
 	System::set_extrinsic_index(extrinsic_index);

--- a/pallets/clusters/src/dummy_data.rs
+++ b/pallets/clusters/src/dummy_data.rs
@@ -9,14 +9,19 @@ pub struct DummyCluster {
 
 pub struct DummyRole {
 	pub name: Vec<u8>,
-	pub settings: Vec<RoleSetting>,
+	pub settings: Vec<DummyRoleSetting>,
+}
+
+pub struct DummyRoleSetting {
+	pub name: Vec<u8>,
+	pub data: Vec<u8>,
 }
 
 pub struct DummyData {
 	pub cluster: DummyCluster,
 	pub role: DummyRole,
-	pub role_settings: RoleSetting,
-	pub role_settings_2: RoleSetting,
+	pub role_settings: DummyRoleSetting,
+	pub role_settings_2: DummyRoleSetting,
 	pub account_id: Public,
 	pub account_id_2: Public,
 }
@@ -37,12 +42,29 @@ pub fn get_vault_account_id(cluster_id: Hash128) -> sp_core::ed25519::Public {
 	sp_core::ed25519::Public::from_raw(hash)
 }
 
+pub fn take_name_index_(name: &Vec<u8>) -> Compact<u64> {
+	let name_index = <Names<Test>>::get(name);
+	if let Some(name_index) = name_index {
+		<Compact<u64>>::from(name_index)
+	} else {
+		let next_name_index = <NamesIndex<Test>>::try_get().unwrap_or_default() + 1;
+		let next_name_index_compact = <Compact<u64>>::from(next_name_index);
+		<Names<Test>>::insert(name, next_name_index_compact);
+		// storing is dangerous inside a closure
+		// but after this call we start storing..
+		// so it's fine here
+		<NamesIndex<Test>>::put(next_name_index);
+		next_name_index_compact
+	}
+}
+
 impl DummyData {
 	pub fn new() -> Self {
-		let role_settings = RoleSetting { name: b"Setting One".to_vec(), data: b"Data One".to_vec() };
-		let role_settings_2 = RoleSetting { name: b"Setting Two".to_vec(), data: b"Data Two".to_vec() };
+		let role_settings = DummyRoleSetting { name: b"Setting One".to_vec(), data: b"Data One".to_vec() };
+		let role_settings_ = DummyRoleSetting { name: b"Setting One".to_vec(), data: b"Data One".to_vec() };
+		let role_settings_2 = DummyRoleSetting { name: b"Setting Two".to_vec(), data: b"Data Two".to_vec() };
 
-		let role = DummyRole { name: b"Role1".to_vec(), settings: vec![role_settings.clone()] };
+		let role = DummyRole { name: b"Role1".to_vec(), settings: vec![role_settings_] };
 
 		let cluster =
 			DummyCluster { owner: Public::from_raw([1u8; 32]), name: b"Cluster1".to_vec() };

--- a/pallets/clusters/src/lib.rs
+++ b/pallets/clusters/src/lib.rs
@@ -607,6 +607,12 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Utility function that checks for the existence of a name in storage and return its index.
+		///
+		/// - `name`: the reference of the name to lookup
+		///
+		/// Returns:
+		/// - `Compact<u64>`: the index of the name in storage
 		pub fn take_name_index(name: &Vec<u8>) -> Compact<u64> {
 			let name_index = <Names<T>>::get(name);
 			if let Some(name_index) = name_index {

--- a/pallets/clusters/src/tests.rs
+++ b/pallets/clusters/src/tests.rs
@@ -196,13 +196,10 @@ mod create_tests {
 			let account_id = dummy.account_id;
 
 			assert_ok!(create_cluster_(account_id, cluster.clone()));
-			assert_ok!(create_cluster_(account_id, b"cluster2".to_vec()));
 
 			let extrinsic_index = <frame_system::Pallet<Test>>::extrinsic_index().unwrap();
-
 			let cluster_id = get_cluster_id(cluster.clone(), account_id, extrinsic_index);
 
-			let name_index = take_name_index_(&cluster);
 			let name_setting_index = take_name_index_(&settings.name);
 			let role_setting = RoleSetting { name: name_setting_index, data: settings.data };
 
@@ -213,10 +210,10 @@ mod create_tests {
 				vec![role_setting]
 			));
 
-			//let expected_role = Role { name: name_index, settings: vec![role_setting] };
+			let role_name_index = take_name_index_(&role);
 
 			let roles_in_cluster = <Clusters<Test>>::get(cluster_id).unwrap().roles;
-			assert!(roles_in_cluster.contains(&name_index));
+			assert!(roles_in_cluster.contains(&role_name_index));
 			//assert_eq!(<Roles<Test>>::get(&cluster_id, &name_index).unwrap(), expected_role);
 
 			System::assert_has_event(
@@ -374,6 +371,7 @@ mod create_tests {
 
 			let cluster_id = get_cluster_id(cluster.clone(), account_id, extrinsic_index);
 
+			let role_name_index = take_name_index_(&role);
 			let name_setting_index = take_name_index_(&settings.name);
 			let role_setting1 = RoleSetting { name: name_setting_index, data: settings.data };
 			// associate the role to the cluster
@@ -382,6 +380,13 @@ mod create_tests {
 				cluster_id.clone(),
 				role.clone(),
 				vec![role_setting1.clone()]
+			));
+
+			assert_ok!(add_role_settings_(
+				account_id.clone(),
+				cluster_id.clone(),
+				role.clone(),
+				vec![role_setting1.clone()],
 			));
 
 			let name_setting_index2 = take_name_index_(&settings2.name);
@@ -394,11 +399,11 @@ mod create_tests {
 				vec![role_setting2.clone()],
 			));
 
-			assert!(!<Roles<Test>>::get(&cluster_id, &name_setting_index)
+			assert!(<Roles<Test>>::get(&cluster_id, &role_name_index)
 				.unwrap()
 				.settings
 				.contains(&role_setting1));
-			assert!(!<Roles<Test>>::get(&cluster_id, &name_setting_index2)
+			assert!(<Roles<Test>>::get(&cluster_id, &role_name_index)
 				.unwrap()
 				.settings
 				.contains(&role_setting2));


### PR DESCRIPTION
This PR optimizes the storage layer in `pallet-clusters`.

Another change in this PR is about `edit_role`, now replaced with smaller functions. I realized that it was somehow overlapping with `add_member` function. The former was adding a `Vec<AccountId>` into the list of members, while the latter was adding a single` AccountId` in the list of members, both of them assigning roles to the members. I found it confusing, so I split `edit_role` into the following smaller functions:
- `add_role_members`, `delete_role_members`, `add_role_settings`, `delete_role_settings`

This makes the whole code easier to read and also more intuitive from a user/API perspective.