### PR TITLE
Remove tickets

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -261,9 +261,9 @@ fn testnet_genesis(
 			keys: initial_authorities.iter().map(|x| (x.4.clone())).collect(),
 		},
 		assets: AssetsConfig {
-			assets: vec![(1337, root_key.clone(), true, 1, false)], // Genesis assets: id, owner, is_sufficient, min_balance, is_tradeable
-			metadata: vec![(1337, "Fragnova Network Tickets".into(), "TICKET".into(), 0)], // Genesis metadata: id, name, symbol, decimals
-			accounts: vec![], // Genesis accounts: id, account_id, balance
+			assets: vec![],
+			metadata: vec![],
+			accounts: vec![],
 		},
 		accounts: AccountsConfig {
 			keys: initial_authorities.iter().map(|x| (x.4.clone())).collect(),

--- a/pallets/accounts/src/dummy_data.rs
+++ b/pallets/accounts/src/dummy_data.rs
@@ -19,20 +19,6 @@ fn get_ethereum_chain_id() -> u64 {
 }
 
 #[cfg(test)]
-pub fn get_ticket_asset_id() -> u64 {
-	use crate::mock::Test;
-	use frame_support::traits::TypedGet;
-	<Test as Config>::TicketsAssetId::get()
-}
-
-#[cfg(test)]
-pub fn get_initial_percentage_tickets() -> u8 {
-	use crate::mock::Test;
-	use frame_support::traits::TypedGet;
-	<Test as Config>::InitialPercentageTickets::get()
-}
-
-#[cfg(test)]
 pub fn get_initial_percentage_nova() -> u8 {
 	use crate::mock::Test;
 	use frame_support::traits::TypedGet;

--- a/pallets/accounts/src/mock.rs
+++ b/pallets/accounts/src/mock.rs
@@ -166,10 +166,6 @@ impl pallet_accounts::EthFragContract for Test {
 	}
 }
 
-parameter_types! {
-	pub const TicketsAssetId: u64 = 1337;
-}
-
 impl pallet_accounts::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
@@ -178,8 +174,6 @@ impl pallet_accounts::Config for Test {
 	type EthFragContract = Test;
 	type Threshold = ConstU64<1>;
 	type AuthorityId = pallet_accounts::crypto::FragAuthId;
-	type TicketsAssetId = TicketsAssetId;
-	type InitialPercentageTickets = ConstU8<80>;
 	type InitialPercentageNova = ConstU8<20>;
 	type USDEquivalentAmount = ConstU128<100>;
 }
@@ -231,23 +225,6 @@ fn create_public_key(keystore: &KeyStore) -> sp_core::ed25519::Public {
 	)
 	.unwrap();
 	keystore.ed25519_public_keys(crate::crypto::Public::ID).get(0).unwrap().clone()
-}
-
-pub fn new_test_ext_with_nova() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-
-	let keystore = KeyStore::new();
-	let ed25519_public_key = create_public_key(&keystore);
-	let config: pallet_assets::GenesisConfig<Test> = pallet_assets::GenesisConfig {
-		assets: vec![(1337, ed25519_public_key, true, 1, false)], // Genesis assets: id, owner, is_sufficient, min_balance, is_tradeable
-		metadata: vec![(1337, Vec::from("Fragnova Network Tickets"), Vec::from("TICKET"), 0)], // Genesis metadata: id, name, symbol, decimals
-		accounts: vec![], // Genesis accounts: id, account_id, balance
-	};
-
-	config.assimilate_storage(&mut t).unwrap();
-	let mut ext: sp_io::TestExternalities = t.into();
-	ext.execute_with(|| System::set_block_number(1)); // if we don't execute this line, Events are not emitted from extrinsics (I don't know why this is the case though)
-	ext
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/accounts/src/tests.rs
+++ b/pallets/accounts/src/tests.rs
@@ -54,14 +54,8 @@ mod link_tests {
 
 			assert_ok!(link_(&link));
 
-			assert!(
-				<EVMLinks<Test>>::get(&link.clamor_account_id).unwrap() ==
-					link.get_ethereum_public_address_of_signer()
-			);
-			assert!(
-				<EVMLinksReverse<Test>>::get(&link.get_ethereum_public_address_of_signer()).unwrap() ==
-					link.clamor_account_id
-			);
+			assert_eq!(<EVMLinks<Test>>::get(&link.clamor_account_id).unwrap(), link.get_ethereum_public_address_of_signer());
+			assert_eq!(<EVMLinksReverse<Test>>::get(&link.get_ethereum_public_address_of_signer()).unwrap(), link.clamor_account_id);
 
 			let event = <frame_system::Pallet<Test>>::events()
 				.pop()
@@ -159,11 +153,8 @@ mod unlink_tests {
 				link.get_ethereum_public_address_of_signer()
 			));
 
-			assert!(<EVMLinks<Test>>::contains_key(&link.clamor_account_id) == false);
-			assert!(
-				<EVMLinksReverse<Test>>::contains_key(&link.get_ethereum_public_address_of_signer()) ==
-					false
-			);
+			assert_eq!(<EVMLinks<Test>>::contains_key(&link.clamor_account_id), false);
+			assert_eq!(<EVMLinksReverse<Test>>::contains_key(&link.get_ethereum_public_address_of_signer()), false);
 
 			assert!(<PendingUnlinks<Test>>::get().contains(&link.clamor_account_id));
 
@@ -340,9 +331,6 @@ mod sync_partner_contracts_tests {
 		let dd = DummyData::new();
 		let lock = dd.lock;
 
-		let to_block =
-			hardcode_expected_request_and_response(&mut offchain_state.write(), lock.clone());
-
 		let expected_data = EthLockUpdate {
 			public: <Test as SigningTypes>::Public::from(ed25519_public_key),
 			..lock.data
@@ -447,7 +435,7 @@ mod internal_lock_update_tests {
 	}
 
 	#[test]
-	fn lock_by_unlinked_account_should_lock_frag_internally_and_reserve_tickets_and_nova() {
+	fn lock_by_unlinked_account_should_lock_frag_internally_and_reserve_nova() {
 		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
@@ -459,7 +447,7 @@ mod internal_lock_update_tests {
 			assert_ok!(lock_(&lock));
 
 			let mut events = <frame_system::Pallet<Test>>::events();
-			assert_eq!(events.clone().len(), 4);
+			assert_eq!(events.clone().len(), 3);
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
 				event,
@@ -487,17 +475,6 @@ mod internal_lock_update_tests {
 				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_nova())
 					* get_usd_equivalent_amount()
 					* get_oracle_price();
-			let initial_tickets_amount =
-				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_tickets())
-					* get_usd_equivalent_amount()
-					* get_oracle_price();
-
-			assert_eq!(
-				<EthReservedTickets<Test>>::get(&lock.data.sender).unwrap(),
-				SaturatedConversion::saturated_into::<<Test as pallet_assets::Config>::Balance>(
-					initial_tickets_amount
-				)
-			);
 
 			assert_eq!(
 				<EthReservedNova<Test>>::get(&lock.data.sender).unwrap(),
@@ -520,7 +497,7 @@ mod internal_lock_update_tests {
 			assert_eq!(<EVMLinkVotingClosed<Test>>::get(&data_hash).unwrap(), current_block_number);
 
 			let mut events = <frame_system::Pallet<Test>>::events();
-			assert_eq!(events.clone().len(), 4);
+			assert_eq!(events.clone().len(), 3);
 
 			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
 			assert_eq!(
@@ -548,27 +525,12 @@ mod internal_lock_update_tests {
 					)
 				})
 			);
-
-			let event = events.pop().expect("Expected at least one EventRecord to be found").event;
-			assert_eq!(
-				event,
-				mock::Event::from(pallet_accounts::Event::TicketsReserved {
-					eth_key: lock.data.sender.clone(),
-					balance: SaturatedConversion::saturated_into::<
-						<Test as pallet_assets::Config>::Balance,
-					>(
-						apply_percent(lock.data.amount.as_u128(), get_initial_percentage_tickets())
-							* get_usd_equivalent_amount()
-							* get_oracle_price()
-					)
-				})
-			);
 		});
 	}
 
 	#[test]
-	fn lock_by_linked_account_should_lock_frag_and_mint_tickets_and_assign_nova() {
-		new_test_ext_with_nova().execute_with(|| {
+	fn lock_by_linked_account_should_lock_frag_and_mint_nova() {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -589,20 +551,10 @@ mod internal_lock_update_tests {
 					last_withdraw: 0,
 				}
 			);
-			// check the balance of the Clamor account
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
 			let initial_nova_amount =
 				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_nova())
 					* get_usd_equivalent_amount()
 					* get_oracle_price();
-			let initial_tickets_amount =
-				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_tickets())
-					* get_usd_equivalent_amount()
-					* get_oracle_price();
-			assert_eq!(U256::from(minted), U256::from(initial_tickets_amount));
 
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(U256::from(nova), U256::from(initial_nova_amount));
@@ -610,8 +562,8 @@ mod internal_lock_update_tests {
 	}
 
 	#[test]
-	fn link_an_account_with_reserved_tickets_and_nova_should_mint_and_increase_balance() {
-		new_test_ext_with_nova().execute_with(|| {
+	fn link_an_account_with_reserved_nova_should_mint_and_increase_balance() {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -636,17 +588,6 @@ mod internal_lock_update_tests {
 				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_nova())
 					* get_usd_equivalent_amount()
 					* get_oracle_price();
-			let initial_tickets_amount =
-				apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_tickets())
-					* get_usd_equivalent_amount()
-					* get_oracle_price();
-
-			assert_eq!(
-				<EthReservedTickets<Test>>::get(&lock.data.sender).unwrap(),
-				SaturatedConversion::saturated_into::<<Test as pallet_assets::Config>::Balance>(
-					initial_tickets_amount
-				)
-			);
 
 			assert_eq!(
 				<EthReservedNova<Test>>::get(&lock.data.sender).unwrap(),
@@ -654,32 +595,18 @@ mod internal_lock_update_tests {
 					initial_nova_amount
 				)
 			);
-			// check the balance of the Clamor account
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-			assert_eq!(minted, 0);
 
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(nova, 0);
 
-			// now link the account to have the reserved tickets and nova minted and put in balance
+			// now link the account to have the reserved nova minted and put in balance
 			// of Clamor account
 			assert_ok!(link_(&link));
-
-			let minted_linked = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-			assert_eq!(minted_linked as u128, initial_tickets_amount);
 
 			let nova_linked =
 				pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 
 			assert_eq!(nova_linked as u128, initial_nova_amount);
-
-			assert_eq!(<EthReservedTickets<Test>>::contains_key(&lock.data.sender), false);
 			assert_eq!(<EthReservedNova<Test>>::contains_key(&lock.data.sender), false);
 		});
 	}
@@ -720,7 +647,7 @@ mod internal_lock_update_tests {
 
 	#[test]
 	fn block_number_of_first_lock_event_should_be_correct() {
-		new_test_ext_with_nova().execute_with(|| {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 
 			let dd = DummyData::new();
@@ -778,18 +705,6 @@ mod internal_lock_update_tests {
 				get_initial_percentage_nova(),
 			) * get_usd_equivalent_amount()
 				* get_oracle_price();
-			let initial_tickets_amount = apply_percent(
-				unlock.lock.data.amount.clone().as_u128(),
-				get_initial_percentage_tickets(),
-			) * get_usd_equivalent_amount()
-				* get_oracle_price();
-
-			assert_eq!(
-				<EthReservedTickets<Test>>::get(&unlock.lock.data.sender).unwrap(),
-				SaturatedConversion::saturated_into::<<Test as pallet_assets::Config>::Balance>(
-					initial_tickets_amount
-				)
-			);
 
 			assert_eq!(
 				<EthReservedNova<Test>>::get(&unlock.lock.data.sender).unwrap(),
@@ -797,12 +712,6 @@ mod internal_lock_update_tests {
 					initial_nova_amount
 				)
 			);
-
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-			assert_eq!(minted, 0);
 
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(nova, 0);
@@ -865,43 +774,26 @@ mod withdraw_tests {
 		Accounts::withdraw(Origin::signed(lock.link.clamor_account_id))
 	}
 
-	pub fn get_initial_amounts(lock: &Lock) -> (u128, u128) {
-		let initial_nova_amount =
+	pub fn get_initial_amounts(lock: &Lock) -> u128 {
 			apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_nova())
 				* get_usd_equivalent_amount()
-				* get_oracle_price();
+				* get_oracle_price()
 
-		let initial_tickets_amount =
-			apply_percent(lock.data.amount.clone().as_u128(), get_initial_percentage_tickets())
-				* get_usd_equivalent_amount()
-				* get_oracle_price();
-
-		(initial_nova_amount, initial_tickets_amount)
 	}
 
 	pub fn expected_nova_amount(week_num: u64, lock_period: u64, data_amount: u128) -> u128 {
 		let nova_per_week = apply_percent(data_amount, 100 - get_initial_percentage_nova())
 			/ u128::try_from(lock_period).unwrap();
 		let expected_amount = nova_per_week
-			* get_usd_equivalent_amount() // tickets per week and 1 FRAG = 100 Tickets. 20% of 100 / 4 weeks
+			* get_usd_equivalent_amount() // NOVA per week and 1 FRAG = 100 NOVA. 80% of 100 / 4 weeks
 			* u128::try_from(week_num).unwrap()
 			* get_oracle_price(); //
 		expected_amount
 	}
 
-	pub fn expected_tickets_amount(week_num: u64, lock_period: u8, data_amount: u128) -> u128 {
-		let tickets_per_week = apply_percent(data_amount, 100 - get_initial_percentage_tickets())
-			/ u128::try_from(lock_period).unwrap();
-		let expected_amount = tickets_per_week
-			* get_usd_equivalent_amount() // tickets per week and 1 FRAG = 100 Tickets. 20% of 100 / 4 weeks
-			* u128::try_from(week_num).unwrap()
-			* get_oracle_price(); // oracle price for 1 FRAG = 1 USD
-		expected_amount
-	}
-
 	#[test]
-	fn withdraw_should_increase_tickets_and_nova_balance() {
-		new_test_ext_with_nova().execute_with(|| {
+	fn withdraw_should_increase_nova_balance() {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -912,16 +804,11 @@ mod withdraw_tests {
 			assert_ok!(lock_(&lock));
 
 			// check the balance of the Clamor account
-			let tickets_balance = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
 			let nova_balance =
 				pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 
-			// initial amounts of Tickets = 80%, NOVA = 20%
-			let (initial_nova_amount, initial_tickets_amount) = get_initial_amounts(&lock);
-			assert_eq!(tickets_balance as u128, initial_tickets_amount);
+			// initial amounts of NOVA = 20%
+			let initial_nova_amount = get_initial_amounts(&lock);
 			assert_eq!(nova_balance as u128, initial_nova_amount);
 
 			let lock_period = <EthLockedFrag<Test>>::get(&lock.data.sender, current_block)
@@ -936,18 +823,7 @@ mod withdraw_tests {
 
 			assert_ok!(withdraw_(&lock)); // withdraw at week 3
 
-			let tickets_balance_after_withdraw = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
 			let data_amount: u128 = lock.data.amount.try_into().ok().unwrap();
-			// 80% of tickets have already been sent to user. 100% - 80% is the remaining amount due.
-			let expected_amount =
-				expected_tickets_amount(week_num.into(), lock_period_in_weeks, data_amount);
-			assert_eq!(
-				tickets_balance_after_withdraw as u128,
-				expected_amount + initial_tickets_amount
-			);
 
 			let expected_amount = expected_nova_amount(
 				week_num.into(),
@@ -962,7 +838,7 @@ mod withdraw_tests {
 
 	#[test]
 	fn withdraw_after_lock_period_is_over_gives_correct_amounts() {
-		new_test_ext_with_nova().execute_with(|| {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -972,14 +848,7 @@ mod withdraw_tests {
 			assert_ok!(link_(&link));
 			assert_ok!(lock_(&lock));
 
-			// check the balance of the Clamor account
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let (initial_nova_amount, initial_tickets_amount) = get_initial_amounts(&lock);
-			assert_eq!(minted as u128, initial_tickets_amount);
+			let initial_nova_amount= get_initial_amounts(&lock);
 
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(nova as u128, initial_nova_amount);
@@ -994,22 +863,7 @@ mod withdraw_tests {
 
 			assert_ok!(withdraw_(&lock));
 
-			let tickets_balance = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
 			let data_amount: u128 = lock.data.amount.try_into().ok().unwrap();
-			// 80% of tickets have already been sent to user. 100% - 80% is the remaining amount due.
-			let expected_amount =
-				expected_tickets_amount(lock_period_in_weeks.into(), lock_period_in_weeks, data_amount);
-
-			assert_eq!(
-				tickets_balance as u128,
-				expected_amount + initial_tickets_amount,
-				"Amount of Tickets minted are equivalent to the max withdrawal amount possible \
-				(i.e. yielded until lock period) even if account withdraws at week 5 (i.e. one week after lock period)"
-			);
-
 			let expected_amount = expected_nova_amount(
 				lock_period_in_weeks.into(),
 				lock_period_in_weeks.into(),
@@ -1025,7 +879,7 @@ mod withdraw_tests {
 
 	#[test]
 	fn subsequent_withdraws_after_one_lock_mint_correct_amounts() {
-		new_test_ext_with_nova().execute_with(|| {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -1049,14 +903,7 @@ mod withdraw_tests {
 				}
 			);
 
-			// check the balance of the Clamor account
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let (initial_nova_amount, initial_tickets_amount) = get_initial_amounts(&lock);
-			assert_eq!(minted as u128, initial_tickets_amount);
+			let initial_nova_amount = get_initial_amounts(&lock);
 
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(nova as u128, initial_nova_amount);
@@ -1086,20 +933,7 @@ mod withdraw_tests {
 				}
 			);
 
-			let tickets_balance_after_1st_withdraw = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
 			let data_amount: u128 = lock.data.amount.try_into().ok().unwrap();
-			// 80% of tickets have already been sent to user. 100% - 80% is the remaining amount due.
-			let expected_amount = expected_tickets_amount(weeks_after_first_lock.clone(), lock_period_in_weeks, data_amount);
-
-			assert_eq!(
-				tickets_balance_after_1st_withdraw as u128,
-				expected_amount + initial_tickets_amount,
-			);
-
 			let expected_amount = expected_nova_amount(weeks_after_first_lock.clone(), lock_period_in_weeks.into(), data_amount.clone());
 			let nova_new_balance =
 				pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
@@ -1113,18 +947,6 @@ mod withdraw_tests {
 				"EthLockedFrag should have been removed for this lock event since all the due amount is yielded and withdrawn."
 			);
 
-			let tickets_balance = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let expected_amount = expected_tickets_amount(lock_period_in_weeks.into(), lock_period_in_weeks.into(), data_amount.clone());
-			assert_eq!(
-				tickets_balance as u128,
-				expected_amount + initial_tickets_amount.clone(),
-				"Amount of Tickets minted are equal to the total amount due after two subsequent withdraws"
-			);
-
 			let expected_amount = expected_nova_amount(lock_period_in_weeks.into(), lock_period_in_weeks.into(), data_amount.clone());
 			let nova_new_balance =
 				pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
@@ -1134,7 +956,7 @@ mod withdraw_tests {
 
 	#[test]
 	fn subsequent_withdraws_after_multiple_locks_produces_correct_lock_registrations() {
-		new_test_ext_with_nova().execute_with(|| {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -1246,7 +1068,7 @@ mod withdraw_tests {
 
 	#[test]
 	fn subsequent_withdraws_after_multiple_locks_produces_correct_balances() {
-		new_test_ext_with_nova().execute_with(|| {
+		new_test_ext().execute_with(|| {
 			let _ = store_price_();
 			let dd = DummyData::new();
 			let lock = dd.lock;
@@ -1268,15 +1090,7 @@ mod withdraw_tests {
 			let current_block = System::block_number();
 			assert_eq!(current_block, 1);
 
-			// check the balance of the Clamor account
-			let minted = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let (initial_nova_amount, initial_tickets_amount) = get_initial_amounts(&lock);
-			assert_eq!(minted as u128, initial_tickets_amount);
-
+			let initial_nova_amount= get_initial_amounts(&lock);
 			let nova = pallet_balances::Pallet::<Test>::free_balance(&link.clamor_account_id);
 			assert_eq!(nova as u128, initial_nova_amount);
 
@@ -1287,43 +1101,11 @@ mod withdraw_tests {
 
 			assert_ok!(lock_(&lock2));
 
-			// check the balance of the Clamor account
-			let minted2 = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let (initial_nova_amount2, initial_tickets_amount2) = get_initial_amounts(&lock2);
-			assert_eq!(minted2 as u128, initial_tickets_amount2 + initial_tickets_amount);
-
+			let initial_nova_amount2= get_initial_amounts(&lock2);
 			let nova2 = pallet_balances::Pallet::<Test>::free_balance(&link2.clamor_account_id);
 			assert_eq!(nova2 as u128, initial_nova_amount2 + initial_nova_amount);
 
 			assert_ok!(withdraw_(&lock)); // withdraw at week 2
-
-			let tickets_balance_after_1st_withdraw = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			// 80% of tickets have already been sent to user. 100% - 80% is the remaining amount due.
-			let expected_amount = expected_tickets_amount(
-				weeks_later_from_first_lock.clone(),
-				lock_period_in_weeks,
-				data_amount,
-			);
-			let expected_amount2 = expected_tickets_amount(
-				weeks_later_from_first_lock.clone() - 1,
-				lock_period_in_weeks2,
-				data_amount2,
-			);
-
-			assert_eq!(
-				tickets_balance_after_1st_withdraw as u128,
-				expected_amount
-					+ expected_amount2 + initial_tickets_amount.clone()
-					+ initial_tickets_amount2.clone(),
-			);
 
 			let expected_amount = expected_nova_amount(
 				weeks_later_from_first_lock.clone(),
@@ -1349,28 +1131,6 @@ mod withdraw_tests {
 			System::set_block_number(next_week);
 
 			assert_ok!(withdraw_(&lock)); // withdraw at week 1
-
-			let tickets_balance = pallet_assets::Pallet::<Test>::balance(
-				get_ticket_asset_id(),
-				&link.clamor_account_id,
-			);
-
-			let expected_amount = expected_tickets_amount(
-				lock_period_in_weeks.into(),
-				lock_period_in_weeks.into(),
-				data_amount.clone(),
-			);
-			let expected_amount2 = expected_tickets_amount(
-				(lock_period_in_weeks - 1).into(),
-				lock_period_in_weeks2,
-				data_amount2.clone(),
-			);
-			assert_eq!(
-				tickets_balance as u128,
-				expected_amount
-					+ expected_amount2 + initial_tickets_amount.clone()
-					+ initial_tickets_amount2.clone(),
-			);
 
 			let expected_amount = expected_nova_amount(
 				lock_period_in_weeks.into(),

--- a/pallets/accounts/src/weights.rs
+++ b/pallets/accounts/src/weights.rs
@@ -73,7 +73,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
-	// Storage: Accounts EthReservedTickets (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:1 w:0)
 	fn link() -> Weight {
 		(58_668_000 as Weight)
@@ -91,7 +90,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Accounts EVMLinkVotingClosed (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:0 w:1)
-	// Storage: Accounts EthReservedTickets (r:0 w:1)
 	// Storage: Accounts EthLockedFrag (r:0 w:1)
 	fn internal_lock_update() -> Weight {
 		(67_671_000 as Weight)
@@ -137,7 +135,6 @@ impl WeightInfo for () {
 	}
 	// Storage: Accounts EVMLinks (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:1)
-	// Storage: Accounts EthReservedTickets (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:1 w:0)
 	fn link() -> Weight {
 		(58_668_000 as Weight)
@@ -155,7 +152,6 @@ impl WeightInfo for () {
 	// Storage: Accounts EVMLinkVotingClosed (r:1 w:1)
 	// Storage: Accounts EVMLinksReverse (r:1 w:0)
 	// Storage: Accounts EthReservedNova (r:0 w:1)
-	// Storage: Accounts EthReservedTickets (r:0 w:1)
 	// Storage: Accounts EthLockedFrag (r:0 w:1)
 	fn internal_lock_update() -> Weight {
 		(67_671_000 as Weight)

--- a/pallets/aliases/src/mock.rs
+++ b/pallets/aliases/src/mock.rs
@@ -136,10 +136,6 @@ impl pallet_detach::Config for Test {
 
 impl pallet_randomness_collective_flip::Config for Test {}
 
-parameter_types! {
-	pub const TicketsAssetId: u64 = 1337;
-}
-
 impl pallet_accounts::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
@@ -148,8 +144,6 @@ impl pallet_accounts::Config for Test {
 	type EthConfirmations = ConstU64<1>;
 	type Threshold = ConstU64<1>;
 	type AuthorityId = pallet_accounts::crypto::FragAuthId;
-	type TicketsAssetId = TicketsAssetId;
-	type InitialPercentageTickets = sp_runtime::traits::ConstU8<80>;
 	type InitialPercentageNova = sp_runtime::traits::ConstU8<20>;
 	type USDEquivalentAmount = ConstU128<100>;
 }

--- a/pallets/aliases/src/mock.rs
+++ b/pallets/aliases/src/mock.rs
@@ -121,8 +121,6 @@ impl pallet_protos::Config for Test {
 	type DetachAccountLimit = ConstU32<20>;
 	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
-	type CurationExpiration = ConstU64<5>;
-	type TicketsAssetId = TicketsAssetId;
 }
 
 impl pallet_fragments::Config for Test {

--- a/pallets/fragments/src/dummy_data.rs
+++ b/pallets/fragments/src/dummy_data.rs
@@ -31,7 +31,6 @@ mod copied_from_pallet_protos {
 		pub category: Categories,
 		pub tags: Vec<Vec<u8>>,
 		pub linked_asset: Option<pallet_protos::LinkedAsset>,
-		pub include_cost: Option<u64>,
 		pub data: Vec<u8>,
 	}
 	impl ProtoFragment {
@@ -207,7 +206,6 @@ impl DummyData {
 				category: Categories::Text(TextCategories::Plain),
 				tags: Vec::new(),
 				linked_asset: None,
-				include_cost: Some(111),
 				data: "0x111".as_bytes().to_vec(),
 			},
 			metadata: DefinitionMetadata { name: b"Il Nome".to_vec(), currency: Currency::Native },

--- a/pallets/fragments/src/mock.rs
+++ b/pallets/fragments/src/mock.rs
@@ -212,8 +212,6 @@ impl pallet_protos::Config for Test {
 	type DetachAccountLimit = ConstU32<20>;
 	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
-	type CurationExpiration = ConstU64<5>;
-	type TicketsAssetId = TicketsAssetId;
 }
 
 impl pallet_accounts::Config for Test {

--- a/pallets/fragments/src/mock.rs
+++ b/pallets/fragments/src/mock.rs
@@ -201,10 +201,6 @@ impl pallet_contracts::Config for Test {
 	type MaxStorageKeyLen = ConstU32<128>;
 }
 
-parameter_types! {
-	pub const TicketsAssetId: u64 = 1337;
-}
-
 impl pallet_protos::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
@@ -222,8 +218,6 @@ impl pallet_accounts::Config for Test {
 	type EthConfirmations = ConstU64<1>;
 	type Threshold = ConstU64<1>;
 	type AuthorityId = pallet_accounts::crypto::FragAuthId;
-	type TicketsAssetId = TicketsAssetId;
-	type InitialPercentageTickets = ConstU8<80>;
 	type InitialPercentageNova = ConstU8<20>;
 	type USDEquivalentAmount = ConstU128<100>;
 }

--- a/pallets/fragments/src/tests.rs
+++ b/pallets/fragments/src/tests.rs
@@ -37,10 +37,7 @@ mod copied_from_pallet_protos {
 					.collect::<Vec<BoundedVec<_, _>>>()
 			).unwrap(),
 			proto.linked_asset.clone(),
-			proto
-				.include_cost
-				.map(|cost| UsageLicense::Tickets(Compact::from(cost)))
-				.unwrap_or(UsageLicense::Closed),
+			UsageLicense::Closed,
 			None,
 			ProtoData::Local(proto.data.clone()),
 		)

--- a/pallets/protos/src/benchmarking.rs
+++ b/pallets/protos/src/benchmarking.rs
@@ -105,7 +105,7 @@ benchmarks! {
 				format!("{}", i).repeat(<T as pallet::Config>::StringLimit::get() as usize).into_bytes()[0..<T as pallet::Config>::StringLimit::get() as usize].to_vec().try_into().unwrap()
 			}).collect::<Vec<BoundedVec<u8, _>>>().try_into().unwrap()
 		);
-		let license = Some(UsageLicense::Tickets(Compact(100))); // we do this since this will trigger an extra DB write (so it lets us simulate the worst-case scenario)
+		let license = Some(UsageLicense::Open);
 		let data = vec![7u8; d as usize];
 
 	}: patch(RawOrigin::Signed(caller), proto_hash, license, new_references, new_tags, Some(ProtoData::Local(data.clone())))

--- a/pallets/protos/src/dummy_data.rs
+++ b/pallets/protos/src/dummy_data.rs
@@ -29,7 +29,6 @@ pub struct ProtoFragment {
 	pub category: Categories,
 	pub tags: Vec<Vec<u8>>,
 	pub linked_asset: Option<LinkedAsset>,
-	pub include_cost: Option<u64>,
 	pub data: Vec<u8>,
 }
 impl ProtoFragment {
@@ -40,7 +39,6 @@ impl ProtoFragment {
 
 pub struct Patch {
 	pub proto_fragment: ProtoFragment,
-	pub include_cost: Option<u64>,
 	pub new_references: Vec<Hash256>,
 	pub new_data: Vec<u8>,
 }
@@ -58,16 +56,6 @@ pub struct Metadata {
 impl Metadata {
 	pub fn get_data_hash(&self) -> Hash256 {
 		compute_data_hash(&self.data)
-	}
-}
-
-pub struct Stake {
-	pub proto_fragment: ProtoFragment,
-	pub lock: Lock,
-}
-impl Stake {
-	pub fn get_stake_amount(&self) -> u128 {
-		self.proto_fragment.include_cost.unwrap().into()
 	}
 }
 
@@ -91,7 +79,6 @@ pub struct DummyData {
 	pub patch: Patch,
 	pub metadata: Metadata,
 	pub detach: Detach,
-	pub stake: Stake,
 	pub account_id: sp_core::ed25519::Public,
 	pub account_id_second: sp_core::ed25519::Public,
 	pub ethereum_account_id: H160,
@@ -104,7 +91,6 @@ impl DummyData {
 			category: Categories::Text(TextCategories::Plain),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(867),
 			data: "0x111".as_bytes().to_vec(),
 		};
 
@@ -113,7 +99,6 @@ impl DummyData {
 			category: Categories::Text(TextCategories::Plain),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: "0x222".as_bytes().to_vec(),
 		};
 
@@ -133,7 +118,6 @@ impl DummyData {
 			category: Categories::Trait(Some(data_trait)),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: trait1.encode(),
 		};
 
@@ -154,7 +138,6 @@ impl DummyData {
 			category: Categories::Trait(Some(data_trait_2)),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: trait2.encode(),
 		};
 
@@ -174,7 +157,6 @@ impl DummyData {
 			category: Categories::Trait(Some(data_trait_3)),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: trait3.encode(),
 		};
 
@@ -191,7 +173,6 @@ impl DummyData {
 			category: Categories::Shards(shard_script_1),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: "0x661".as_bytes().to_vec(),
 		};
 
@@ -207,7 +188,6 @@ impl DummyData {
 			category: Categories::Shards(shard_script_2),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: "0x667".as_bytes().to_vec(),
 		};
 
@@ -224,7 +204,6 @@ impl DummyData {
 			category: Categories::Shards(shard_script_3),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: "0x669".as_bytes().to_vec(),
 		};
 
@@ -239,13 +218,11 @@ impl DummyData {
 			category: Categories::Shards(shard_script_4),
 			tags: Vec::new(),
 			linked_asset: None,
-			include_cost: Some(2),
 			data: "0x670".as_bytes().to_vec(),
 		};
 
 		let patch = Patch {
 			proto_fragment: proto.clone(),
-			include_cost: Some(123),
 			new_references: Vec::new(),
 			new_data: b"<Insert Anything Here>".to_vec(),
 		};
@@ -266,37 +243,6 @@ impl DummyData {
 		let contract = Address::from_str(&contracts[0].as_str()[2..])
 			.map_err(|_| "Invalid response - invalid sender")
 			.unwrap();
-		let stake = Stake {
-			proto_fragment: proto.clone(),
-			lock: Lock {
-				data: pallet_accounts::EthLockUpdate {
-					public: sp_core::ed25519::Public([69u8; 32]),
-					amount: U256::from(69u32),
-					lock_period: 1,
-					sender: get_ethereum_public_address(&sp_core::ecdsa::Pair::from_seed(
-						&[1u8; 32],
-					)),
-					signature: create_lock_signature(
-						sp_core::ecdsa::Pair::from_seed(&[1u8; 32]),
-						U256::from(69u32),
-						1,
-						get_ethereum_public_address(&sp_core::ecdsa::Pair::from_seed(&[1u8; 32])),
-						contract,
-					),
-					lock: true, // yes, please lock it!
-					block_number: 69,
-				},
-				link: Link {
-					clamor_account_id: sp_core::ed25519::Public::from_raw([255u8; 32]),
-					link_signature: create_link_signature(
-						sp_core::ed25519::Public::from_raw([3u8; 32]),
-						sp_core::ecdsa::Pair::from_seed(&[1u8; 32]),
-					),
-					_ethereum_account_pair: sp_core::ecdsa::Pair::from_seed(&[1u8; 32]),
-				},
-				ethereum_account_pair: sp_core::ecdsa::Pair::from_seed(&[1u8; 32]),
-			},
-		};
 
 		Self {
 			proto_fragment: proto,
@@ -311,7 +257,6 @@ impl DummyData {
 			patch,
 			metadata,
 			detach,
-			stake,
 			account_id: sp_core::ed25519::Public::from_raw([1u8; 32]),
 			account_id_second: sp_core::ed25519::Public::from_raw([2u8; 32]),
 			ethereum_account_id: H160::random(),

--- a/pallets/protos/src/mock.rs
+++ b/pallets/protos/src/mock.rs
@@ -197,8 +197,6 @@ impl pallet_protos::Config for Test {
 	type DetachAccountLimit = ConstU32<20>;
 	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
-	type CurationExpiration = ConstU64<5>;
-	type TicketsAssetId = TicketsAssetId;
 }
 
 impl pallet_detach::Config for Test {

--- a/pallets/protos/src/mock.rs
+++ b/pallets/protos/src/mock.rs
@@ -148,10 +148,6 @@ impl pallet_balances::Config for Test {
 	type IsTransferable = IsTransferable;
 }
 
-parameter_types! {
-	pub const TicketsAssetId: u64 = 1337;
-}
-
 impl pallet_accounts::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
@@ -160,8 +156,6 @@ impl pallet_accounts::Config for Test {
 	type EthConfirmations = ConstU64<1>;
 	type Threshold = ConstU64<1>;
 	type AuthorityId = pallet_accounts::crypto::FragAuthId;
-	type TicketsAssetId = TicketsAssetId;
-	type InitialPercentageTickets = sp_runtime::traits::ConstU8<80>;
 	type InitialPercentageNova = sp_runtime::traits::ConstU8<20>;
 	type USDEquivalentAmount = ConstU128<100>;
 }

--- a/rpc/index.js
+++ b/rpc/index.js
@@ -122,7 +122,6 @@ const connectToLocalNode = async () => {
         _enum: {
           "Closed": null,
           "Open": null,
-          "Tickets": "Compact<u64>",
           "Contract": "AccountId",
         }
       },

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -481,8 +481,6 @@ impl pallet_protos::Config for Runtime {
 	type DetachAccountLimit = ConstU32<20>; // An ethereum public account address has a length of 20.
 	type MaxTags = ConstU32<10>;
 	type StorageBytesMultiplier = StorageBytesMultiplier;
-	type CurationExpiration = ConstU64<100800>; // one week
-	type TicketsAssetId = TicketsAssetId;
 }
 
 impl pallet_detach::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -431,10 +431,6 @@ impl pallet_accounts::EthFragContract for Runtime {
 	}
 }
 
-parameter_types! {
-	pub const TicketsAssetId: u64 = 1337;
-}
-
 impl pallet_accounts::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = ();
@@ -443,8 +439,6 @@ impl pallet_accounts::Config for Runtime {
 	type EthConfirmations = ConstU64<1>;
 	type Threshold = ConstU64<1>;
 	type AuthorityId = pallet_accounts::crypto::FragAuthId;
-	type TicketsAssetId = TicketsAssetId;
-	type InitialPercentageTickets = sp_runtime::traits::ConstU8<80>;
 	type InitialPercentageNova = ConstU8<20>;
 	type USDEquivalentAmount = ConstU128<100>;
 }


### PR DESCRIPTION
Remove from `pallet-protos`, `pallet-accounts` and `genesis`.

Notes for `pallet-accounts`: 
- `link` function now only mints 20% of NOVA and 80% are vested.
- `withdraw` function only for NOVA.